### PR TITLE
Add a Julia PKG scanner

### DIFF
--- a/automations/17_run_julia_scanner.sh
+++ b/automations/17_run_julia_scanner.sh
@@ -13,7 +13,37 @@ fi
 
 projectID=$1
 
+# Check for Manifest.toml and Project.toml files
+manifest_files=$(find $projectID -name 'Manifest.toml')
+project_files=$(find $projectID -name 'Project.toml')
+
+# Generate Markdown formatted checklist
+checklist="## Julia Project Checklist\n\n"
+checklist+="| File          | Present |\n"
+checklist+="|---------------|---------|\n"
+
+if [ -n "$manifest_files" ]; then
+  for file in $manifest_files; do
+    checklist+="| $file | Yes |\n"
+  done
+else
+  checklist+="| Manifest.toml | No |\n"
+fi
+
+if [ -n "$project_files" ]; then
+  for file in $project_files; do
+    checklist+="| $file | Yes |\n"
+  done
+else
+  checklist+="| Project.toml | No |\n"
+fi
+
+echo -e "$checklist" > generated/julia_project_checklist.md
 
 # Run the Julia scanner using `pkgdeps`
 julia tools/scan_pkg.jl $projectID generated/julia_pkgs.csv
 
+# Convert CSV to Markdown
+if [ -f generated/julia_pkgs.csv ]; then
+  python3 tools/csv2md.py generated/julia_pkgs.csv
+fi

--- a/automations/17_run_julia_scanner.sh
+++ b/automations/17_run_julia_scanner.sh
@@ -38,7 +38,7 @@ else
   checklist+="| Project.toml | No |\n"
 fi
 
-echo -e "$checklist" > generated/julia_project_checklist.md
+echo -e "$checklist" > generated/julia_toml_chks.md
 
 # Run the Julia scanner using `pkgdeps`
 julia tools/scan_pkg.jl $projectID generated/julia_pkgs.csv

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -142,6 +142,17 @@ pipelines:
             artifacts:
               - generated/**
         - step:
+            name: Run Julia parser
+            image: julia:latest
+            script:
+              - . ./tools/parse_yaml.sh
+              - eval $(parse_yaml config.yml)
+              - chmod a+rx ./automations/*.sh
+              - ./automations/00_preliminaries.sh $ProcessJulia $openICPSRID
+              - ./automations/17_run_julia_scanner.sh $openICPSRID
+            artifacts:
+              - generated/**
+        - step:
             name: Count lines and comments
             image:
               name: aldanial/cloc


### PR DESCRIPTION
Related to #43

Add Julia PKG scanner and generate Markdown formatted checklist

* Modify `automations/17_run_julia_scanner.sh` to check for `Manifest.toml` and `Project.toml` files using the `find` command, generate a Markdown formatted checklist, and save it as `generated/julia_project_checklist.md`.
* Run the Julia scanner using `pkgdeps` and output the results to `generated/julia_pkgs.csv`.
* Convert the CSV output to a Markdown formatted table and save it as `generated/julia_pkgs.md`.
* Modify `bitbucket-pipelines.yml` to add a step for running the Julia scanner in parallel to the existing scripts in the `1-populate-from-icpsr` custom test.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AEADataEditor/replication-template-development/pull/45?shareId=f4fb57ed-a5d8-45f7-ac6f-def1ccd6911f).