### PR TITLE
Make python calls platform dependent

### DIFF
--- a/automations/00_preliminaries.sh
+++ b/automations/00_preliminaries.sh
@@ -2,9 +2,19 @@
 
 if [ "$1" == "no" ]; then exit 0; fi
 
+# Define the $pythonbin variable based on the operating system using a case statement
+case "$(uname -o)" in
+  Msys)
+    pythonbin="python"
+    ;;
+  *)
+    pythonbin="python3"
+    ;;
+esac
+
 projectID=$2
 
 if [ -d cache ]; then ls -lR cache/*; fi
 if [ -f cache/$projectID.zip ]; then mv cache/$projectID.zip .; fi
-if [ ! -f $projectID.zip ]; then python3 tools/download_openicpsr-private.py $projectID; fi
+if [ ! -f $projectID.zip ]; then $pythonbin tools/download_openicpsr-private.py $projectID; fi
 ./automations/00_unpack_zip.sh  $projectID

--- a/automations/10_run_stata_scanner.sh
+++ b/automations/10_run_stata_scanner.sh
@@ -4,6 +4,16 @@ set -ev
 [[ "$SkipProcessing" == "yes" ]] && exit 0
 [[ "$ProcessStata" == "no" ]] && exit 0
 
+# Define the $pythonbin variable based on the operating system using a case statement
+case "$(uname -o)" in
+  Msys)
+    pythonbin="python"
+    ;;
+  *)
+    pythonbin="python3"
+    ;;
+esac
+
 if [ -z $1 ]
 then
 cat << EOF
@@ -52,4 +62,4 @@ then
   mv $directory/candidatepackages.xlsx generated/
 fi
 if [ -f $directory/candidatepackages.csv ]; then mv $directory/candidatepackages.csv generated/; fi
-if [ -f generated/candidatepackages.csv ]; then python3 tools/csv2md.py generated/candidatepackages.csv; fi
+if [ -f generated/candidatepackages.csv ]; then $pythonbin tools/csv2md.py generated/candidatepackages.csv; fi

--- a/automations/15_run_python_scanner.sh
+++ b/automations/15_run_python_scanner.sh
@@ -5,22 +5,31 @@ set -ev
 [[ "$SkipProcessing" == "yes" ]] && exit 0
 [[ "$ProcessPython" == "no" ]] && exit 0
 
+# Define the $pythonbin variable based on the operating system using a case statement
+case "$(uname -o)" in
+  Msys)
+    pythonbin="python"
+    ;;
+  *)
+    pythonbin="python3"
+    ;;
+esac
+
 if [ ! -d generated ] 
 then 
   mkdir generated
 fi
 
 projectID=$1
-if [ -f tools/requirements-scanner.txt ]; then pip install -r tools/requirements-scanner.txt; fi
+if [ -f tools/requirements-scanner.txt ]; then $pythonbin -m pip install -r tools/requirements-scanner.txt; fi
 
 # Run the Python scanner using `pipreqs`
 cd $projectID
-pipreqs . | tee ../generated/python-scanner.log
+$pythonbin -m pipreqs . | tee ../generated/python-scanner.log
 cd ..
 if [ -f $projectID/requirements.txt ]
 then 
     echo "Packages" > generated/python-deps.csv
     cat $projectID/requirements.txt >> generated/python-deps.csv
 fi
-if [ -f generated/python-deps.csv ]; then python3 tools/csv2md.py generated/python-deps.csv; fi
-
+if [ -f generated/python-deps.csv ]; then $pythonbin tools/csv2md.py generated/python-deps.csv; fi


### PR DESCRIPTION
Fixes #52

Make python calls platform dependent by defining the `$pythonbin` variable based on the operating system.

* **Define `$pythonbin` variable:**
  - In `automations/00_preliminaries.sh`, add a case statement to define `$pythonbin` based on the operating system using `uname -o`.
  - In `automations/10_run_stata_scanner.sh`, add a case statement to define `$pythonbin` based on the operating system using `uname -o`.
  - In `automations/15_run_python_scanner.sh`, add a case statement to define `$pythonbin` based on the operating system using `uname -o`.

* **Replace direct calls to `python3` with `$pythonbin`:**
  - In `automations/00_preliminaries.sh`, replace the direct call to `python3` with `$pythonbin`.
  - In `automations/10_run_stata_scanner.sh`, replace the direct call to `python3` with `$pythonbin`.
  - In `automations/15_run_python_scanner.sh`, replace the direct call to `python3` with `$pythonbin`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AEADataEditor/replication-template-development/pull/53?shareId=63e64f6f-d71f-4e29-afaa-1b4b5d8a0fac).