### PR TITLE
Fall back to a Jira comment when the Software used field write fails

### DIFF
--- a/automations/26_update_jira_software.sh
+++ b/automations/26_update_jira_software.sh
@@ -10,6 +10,16 @@
 # Usage: 26_update_jira_software.sh <project-dir> [tag]
 #   project-dir  Directory the deposit was unpacked into (used to inspect .ipynb kernel language).
 #   tag          Optional. Matches the $tag suffix used by 04_list_program_files.sh, if any.
+#
+# Stdout carries only the "Software detected: ..." line (if any software was
+# found), so a caller can capture it and forward it to 70_publish_comment.sh
+# as a durable fallback for cases where the "Software used" field write fails
+# (e.g. customfield_10028 missing from an issue's screen). All other
+# diagnostics go to stderr.
+#
+# Exit code propagates tools/jira_update_software.py's status (0 success,
+# 1 on failure to update Jira); append `|| true` at the call site if the
+# pipeline should continue regardless.
 
 _project_dir="${1:-}"
 _tag="${2:-}"
@@ -19,7 +29,7 @@ if command -v python3.12 &>/dev/null; then
 elif command -v python3 &>/dev/null; then
     PYTHON_CMD="python3"
 else
-    echo "26_update_jira_software: no Python 3 found, skipping"
+    echo "26_update_jira_software: no Python 3 found, skipping" >&2
     exit 0
 fi
 
@@ -28,20 +38,20 @@ _suffix=""
 _metadata="generated/programs-metadata${_suffix}.csv"
 
 if [ ! -f "$_metadata" ]; then
-    echo "26_update_jira_software: $_metadata not found, skipping"
+    echo "26_update_jira_software: $_metadata not found, skipping" >&2
     exit 0
 fi
 
 _jira="${jiraticket:-}"
-echo "26_update_jira_software: jiraticket from environment: '${_jira}'"
+echo "26_update_jira_software: jiraticket from environment: '${_jira}'" >&2
 
 if [ -z "$_jira" ]; then
     if [ -f config.yml ] && [ -f tools/parse_yaml.sh ]; then
         . ./tools/parse_yaml.sh
         _jira=$(parse_yaml config.yml | grep '^jiraticket=' | sed 's/jiraticket=//;s/"//g')
-        echo "26_update_jira_software: jiraticket from config.yml: '${_jira}'"
+        echo "26_update_jira_software: jiraticket from config.yml: '${_jira}'" >&2
     else
-        echo "26_update_jira_software: config.yml or parse_yaml.sh not found, skipping config.yml lookup"
+        echo "26_update_jira_software: config.yml or parse_yaml.sh not found, skipping config.yml lookup" >&2
     fi
 fi
 
@@ -49,20 +59,27 @@ if [ -z "$_jira" ]; then
     _icpsr=$(find . -maxdepth 1 -mindepth 1 -type d -name '[123][0-9][0-9][0-9][0-9][0-9]' 2>/dev/null \
              | head -1 | xargs -I{} basename {} 2>/dev/null || true)
     if [ -n "$_icpsr" ]; then
-        echo "26_update_jira_software: detected openICPSR directory '${_icpsr}', looking up Jira ticket"
+        echo "26_update_jira_software: detected openICPSR directory '${_icpsr}', looking up Jira ticket" >&2
         _jira=$($PYTHON_CMD tools/jira_find_task_by_icpsr.py "$_icpsr" 2>&1) || true
-        echo "26_update_jira_software: jiraticket from lookup: '${_jira}'"
+        echo "26_update_jira_software: jiraticket from lookup: '${_jira}'" >&2
     else
-        echo "26_update_jira_software: no openICPSR directory found"
+        echo "26_update_jira_software: no openICPSR directory found" >&2
     fi
 fi
 
 if [ -z "$_jira" ]; then
-    echo "26_update_jira_software: no Jira ticket found, skipping"
+    echo "26_update_jira_software: no Jira ticket found, skipping" >&2
     exit 0
 fi
 
-$PYTHON_CMD tools/jira_update_software.py "$_jira" "$_metadata" --project-dir "$_project_dir" --yes || \
-    echo "26_update_jira_software: Warning - failed to update Software used field"
+_output=$($PYTHON_CMD tools/jira_update_software.py "$_jira" "$_metadata" --project-dir "$_project_dir" --yes 2>&1)
+_rc=$?
+echo "$_output" >&2
+[ $_rc -eq 0 ] || echo "26_update_jira_software: Warning - failed to update Software used field" >&2
 
-exit 0
+_sw_line=$(echo "$_output" | grep '^Software detected:')
+if [ -n "$_sw_line" ] && [ "$_sw_line" != "Software detected: (none)" ]; then
+    echo "$_sw_line"
+fi
+
+exit $_rc

--- a/automations/70_publish_comment.sh
+++ b/automations/70_publish_comment.sh
@@ -3,13 +3,17 @@
 # Post a status comment to the Jira issue associated with this repository.
 # Ticket resolved in order: $jiraticket env var → config.yml → openICPSR directory detection.
 #
-# Usage: 70_publish_comment.sh [pipeline-name] [status]
+# Usage: 70_publish_comment.sh [pipeline-name] [status] [extra-message]
 #   pipeline-name  Optional. Name of the Bitbucket custom pipeline (e.g., "1-populate-from-icpsr").
 #                  No Bitbucket built-in variable exposes this; pass it explicitly from the pipeline.
 #   status         Optional. Status of the pipeline: "started" or "completed" (default: "completed").
+#   extra-message  Optional. Appended to the comment as-is, e.g. the
+#                  "Software detected: ..." line captured from
+#                  26_update_jira_software.sh's stdout.
 
 _pipeline="${1:-}"
 _status="${2:-completed}"
+_extra="${3:-}"
 
 # Detect Python command
 if command -v python3.12 &>/dev/null; then
@@ -67,8 +71,9 @@ fi
 if [ -n "$_jira" ]; then
     _url="https://bitbucket.org/$BITBUCKET_WORKSPACE/$BITBUCKET_REPO_SLUG/pipelines/results/$BITBUCKET_BUILD_NUMBER"
     echo "70_publish_comment: posting ${_verb} comment to ${_jira}"
-    $PYTHON_CMD tools/jira_add_comment.py "$_jira" \
-        "${_emoji} Bitbucket Pipeline ${_pipeline} ${_verb}. Build [#$BITBUCKET_BUILD_NUMBER|$_url]." || true
+    _comment="${_emoji} Bitbucket Pipeline ${_pipeline} ${_verb}. Build [#$BITBUCKET_BUILD_NUMBER|$_url]."
+    [ -z "$_extra" ] || _comment="${_comment} ${_extra}"
+    $PYTHON_CMD tools/jira_add_comment.py "$_jira" "$_comment" || true
 else
     echo "70_publish_comment: no Jira ticket found, skipping comment"
 fi

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -281,8 +281,8 @@ pipelines:
             - ./automations/30_download_commit_jira_attachments.sh
             - git status
             - git push && git push --tags
-            - ./automations/26_update_jira_software.sh $projectID
-            - ./automations/70_publish_comment.sh 1-populate-from-icpsr completed
+            - swDetected=$(./automations/26_update_jira_software.sh $projectID) || true
+            - ./automations/70_publish_comment.sh 1-populate-from-icpsr completed "$swDetected"
     2-merge-report: #name of this pipeline
       - variables:          #list variable names under here
           - name: jiraticket
@@ -496,8 +496,8 @@ pipelines:
             - git add -f generated/*
             - git diff --cached --quiet || git commit -m "[skip ci] Refreshed data/program listings from manifest"
             - git push
-            - ./automations/26_update_jira_software.sh $openICPSRID "$tag"
-            - ./automations/70_publish_comment.sh r-refresh-lists-from-manifest completed
+            - swDetected=$(./automations/26_update_jira_software.sh $openICPSRID "$tag") || true
+            - ./automations/70_publish_comment.sh r-refresh-lists-from-manifest completed "$swDetected"
     w-big-populate-from-icpsr: #name of this pipeline
       - variables:          #list variable names under here
           # These do not need to have a value, if "config.yml" is filled out.
@@ -550,8 +550,8 @@ pipelines:
             - git status
             - git push
             - git push --tags
-            - ./automations/26_update_jira_software.sh $projectID
-            - ./automations/70_publish_comment.sh w-big-populate-from-icpsr completed
+            - swDetected=$(./automations/26_update_jira_software.sh $projectID) || true
+            - ./automations/70_publish_comment.sh w-big-populate-from-icpsr completed "$swDetected"
 
     x-run-python:
       - variables: 

--- a/tools/jira_update_software.py
+++ b/tools/jira_update_software.py
@@ -258,7 +258,7 @@ def main(argv=None):
 
     found, unmatched = resolve_software(filenames, args.project_dir, ext_lookup, name_lookup)
 
-    print(f"Software detected: {', '.join(sorted(found)) or '(none)'}")
+    print(f"Software detected: {' '.join(sorted(found)) or '(none)'}")
     if unmatched:
         print("Files not mapped to any software (indeterminate/excluded), by extension:")
         for key, count in sorted(unmatched.items()):


### PR DESCRIPTION
## Summary
- The pipeline's `26_update_jira_software.sh` step regularly fails to set Jira's "Software used" field (`customfield_10028`) with `Field 'customfield_10028' cannot be set. It is not on the appropriate screen, or unknown.` on tickets where that field isn't on the issue's edit screen — losing the detected-software info.
- `26_update_jira_software.sh` now propagates its real exit code and prints only the `Software detected: ...` line to stdout (all other diagnostics moved to stderr), so pipeline steps can capture that line cleanly.
- `70_publish_comment.sh` gains an optional third `extra-message` argument that's appended to the Jira comment it already posts.
- `bitbucket-pipelines.yml`'s three call sites now capture `26_update_jira_software.sh`'s stdout and forward it to `70_publish_comment.sh`, so the detected software is always visible as a Jira comment — permanently, not only as an error-path fallback — regardless of whether the custom-field write succeeds.

## Test plan
- [x] `bash -n` on both modified shell scripts
- [x] `python3 -c "import yaml; yaml.safe_load(open('bitbucket-pipelines.yml'))"`
- [x] `python3 tools/test_jira_update_software.py` (unchanged, still passing — 32 tests)
- [x] Manually exercised `26_update_jira_software.sh`'s skip path (no metadata file) — confirmed empty stdout, exit 0, diagnostics on stderr
- [x] Manually exercised the field-write-failure path with a stubbed `jira` module reproducing the exact `customfield_10028` screen error — confirmed `stdout` is `Software detected: Stata`, exit code propagates as 1, diagnostics on stderr
- [ ] Live pipeline run against a real Jira ticket whose screen is missing `customfield_10028` (root cause of the field failures is out of scope for this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)