### PR TITLE
Fix download_zenodo.py for zenodo.org/me/requests/ URLs

### DIFF
--- a/docs/tools/download/96-90-download_zenodo.md
+++ b/docs/tools/download/96-90-download_zenodo.md
@@ -23,6 +23,7 @@ the "Replication package URL".
 python3.12 tools/download_zenodo.py --zenodo-id 10848594
 python3.12 tools/download_zenodo.py --zenodo-id https://zenodo.org/records/10848594
 python3.12 tools/download_zenodo.py --zenodo-id https://zenodo.org/communities/aeajournals/requests/61cff0cb-b3ca-48aa-bfe6-5b17dc8eb665
+python3.12 tools/download_zenodo.py --zenodo-id https://zenodo.org/me/requests/61cff0cb-b3ca-48aa-bfe6-5b17dc8eb665
 
 # From Jira ticket
 python3.12 tools/download_zenodo.py --jira-ticket AEAREP-8983
@@ -47,7 +48,7 @@ zenodo_dir=$(python3.12 tools/download_zenodo.py --zenodo-id "$ZenodoID" --print
 |-------------|--------------|
 | `/records/NNNNN`, `/record/NNNNN`, `10.5281/zenodo.NNNNN`, bare ID | `download_zenodo_public.py` |
 | `/deposit/NNNNN` | `download_zenodo_draft.py` |
-| `/communities/.../requests/{uuid}` | `download_zenodo_draft.py` (resolves UUID → record ID via API) |
+| `/communities/.../requests/{uuid}`, `/me/requests/{uuid}` | `download_zenodo_draft.py` (resolves UUID → record ID via API) |
 
 ## Environment Variables
 

--- a/docs/tools/download/96-90-download_zenodo_draft.md
+++ b/docs/tools/download/96-90-download_zenodo_draft.md
@@ -111,17 +111,29 @@ This tool is essential for working with unpublished Zenodo deposits in research 
 
 ## Community Request URLs
 
-Draft deposits under community review can be addressed using the request URL:
+Draft deposits under community review can be addressed using either form of
+request URL:
 
 ```text
 https://zenodo.org/communities/<community>/requests/<uuid>
+https://zenodo.org/me/requests/<uuid>
 ```
 
-The script calls `GET /api/requests/{uuid}` to resolve the deposit record ID,
-then proceeds with the normal draft download.  An access token is required.
+(the `me/requests` form is what Zenodo shows a reviewer on their own "My
+requests" page, and may carry a trailing `.zip`, e.g.
+`https://zenodo.org/me/requests/<uuid>.zip`; the `.zip` suffix is ignored.)
+
+The script calls `GET /api/requests/{uuid}` to resolve the deposit/record ID
+— accepting either a bare ID string or a `{"id": ...}` object in the
+response's `topic.deposit`/`topic.record` field — then proceeds with the
+normal draft download.  An access token is required.
 
 ```bash
 python3.12 tools/download_zenodo_draft.py \
   https://zenodo.org/communities/aeajournals/requests/61cff0cb-b3ca-48aa-bfe6-5b17dc8eb665 \
+  --access-token $ZENODO_ACCESS_TOKEN
+
+python3.12 tools/download_zenodo_draft.py \
+  https://zenodo.org/me/requests/61cff0cb-b3ca-48aa-bfe6-5b17dc8eb665 \
   --access-token $ZENODO_ACCESS_TOKEN
 ```

--- a/tools/download_zenodo.py
+++ b/tools/download_zenodo.py
@@ -52,7 +52,7 @@ from pathlib import Path
 # ── URL classification ────────────────────────────────────────────────────────
 
 _REQUEST_RE = re.compile(
-    r'zenodo\.org/communities/[^/]+/requests/([0-9a-f-]{36})',
+    r'zenodo\.org/(?:communities/[^/]+/requests|me/requests)/([0-9a-f-]{36})',
     re.IGNORECASE,
 )
 _DEPOSIT_RE = re.compile(r'zenodo\.org/(?:deposit/|deposits/)(\d+)', re.IGNORECASE)

--- a/tools/download_zenodo_draft.py
+++ b/tools/download_zenodo_draft.py
@@ -334,7 +334,7 @@ def get_access_token(provided_token=None):
     return None
 
 REQUEST_URL_PATTERN = re.compile(
-    r'zenodo\.org/communities/[^/]+/requests/([0-9a-f-]{36})',
+    r'zenodo\.org/(?:communities/[^/]+/requests|me/requests)/([0-9a-f-]{36})',
     re.IGNORECASE,
 )
 
@@ -381,11 +381,13 @@ def resolve_request_to_record_id(request_uuid: str, access_token: str, sandbox: 
 
     data = resp.json()
 
-    # Try topic.deposit.id or topic.record.id first
+    # Try topic.deposit(.id) or topic.record(.id) first. The topic value may be
+    # a bare ID string or a dict with an 'id' field, depending on API version.
     topic = data.get('topic', {})
     for key in ('deposit', 'record'):
         if key in topic:
-            record_id = str(topic[key].get('id', ''))
+            value = topic[key]
+            record_id = str(value.get('id', '')) if isinstance(value, dict) else str(value)
             if record_id:
                 print(f"Resolved request → record ID: {record_id}")
                 return record_id

--- a/tools/test_download_zenodo.py
+++ b/tools/test_download_zenodo.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Tests for download_zenodo.py. Run: python3 tools/test_download_zenodo.py"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import download_zenodo as dz
+
+
+class TestClassifyUrl(unittest.TestCase):
+    def test_community_request_url(self):
+        kind, ident = dz.classify_url(
+            'https://zenodo.org/communities/foo/requests/61cff0cb-b3ca-48aa-bfe6-5b17dc8eb665'
+        )
+        self.assertEqual(kind, 'request')
+        self.assertEqual(ident, '61cff0cb-b3ca-48aa-bfe6-5b17dc8eb665')
+
+    def test_me_requests_url(self):
+        kind, ident = dz.classify_url(
+            'https://zenodo.org/me/requests/61cff0cb-b3ca-48aa-bfe6-5b17dc8eb665.zip'
+        )
+        self.assertEqual(kind, 'request')
+        self.assertEqual(ident, '61cff0cb-b3ca-48aa-bfe6-5b17dc8eb665')
+
+    def test_deposit_url(self):
+        kind, ident = dz.classify_url('https://zenodo.org/deposit/1234567')
+        self.assertEqual(kind, 'draft')
+        self.assertEqual(ident, '1234567')
+
+    def test_record_url(self):
+        kind, ident = dz.classify_url('https://zenodo.org/records/1234567')
+        self.assertEqual(kind, 'public')
+        self.assertEqual(ident, '1234567')
+
+    def test_bare_id(self):
+        kind, ident = dz.classify_url('1234567')
+        self.assertEqual(kind, 'public')
+        self.assertEqual(ident, '1234567')
+
+    def test_unparseable_raises(self):
+        with self.assertRaises(SystemExit):
+            dz.classify_url('https://zenodo.org/nonsense/path')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test_download_zenodo_draft.py
+++ b/tools/test_download_zenodo_draft.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Tests for download_zenodo_draft.py. Run: python3 tools/test_download_zenodo_draft.py"""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import download_zenodo_draft as dzd
+
+
+class TestIsRequestUrl(unittest.TestCase):
+    def test_community_request_url(self):
+        self.assertTrue(dzd.is_request_url(
+            'https://zenodo.org/communities/foo/requests/61cff0cb-b3ca-48aa-bfe6-5b17dc8eb665'
+        ))
+
+    def test_me_requests_url(self):
+        self.assertTrue(dzd.is_request_url(
+            'https://zenodo.org/me/requests/61cff0cb-b3ca-48aa-bfe6-5b17dc8eb665.zip'
+        ))
+
+    def test_record_url_is_not_request(self):
+        self.assertFalse(dzd.is_request_url('https://zenodo.org/records/1234567'))
+
+
+class TestResolveRequestToRecordId(unittest.TestCase):
+    @patch('download_zenodo_draft.requests.get')
+    def test_topic_record_as_bare_string(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {'topic': {'record': '18940044'}}
+        )
+        record_id = dzd.resolve_request_to_record_id('uuid', 'token')
+        self.assertEqual(record_id, '18940044')
+
+    @patch('download_zenodo_draft.requests.get')
+    def test_topic_deposit_as_dict(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {'topic': {'deposit': {'id': '999'}}}
+        )
+        record_id = dzd.resolve_request_to_record_id('uuid', 'token')
+        self.assertEqual(record_id, '999')
+
+    @patch('download_zenodo_draft.requests.get')
+    def test_falls_back_to_topic_link(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {'links': {'topic': 'https://zenodo.org/api/records/555'}},
+        )
+        record_id = dzd.resolve_request_to_record_id('uuid', 'token')
+        self.assertEqual(record_id, '555')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- `download_zenodo` (`tools/download_zenodo.py`) is failing in CI (see AEAREP-9161) with `zip error: Nothing to do!` because the request-URL regex only matched `zenodo.org/communities/<name>/requests/<uuid>`, not the `zenodo.org/me/requests/<uuid>.zip` URL Zenodo actually gave this ticket's reviewer. The unmatched URL made `classify_url()` exit(1), and the pipeline's `zenodo_dir=$(... 2>&1 | tail -1)` capture picked up the resulting stderr/stdout noise instead of a clean `zenodo-NNNNN` id, corrupting `$projectID` downstream.
- While verifying the fix against the real ticket (live Zenodo API call), also found that `resolve_request_to_record_id()` in `tools/download_zenodo_draft.py` assumed `topic.record`/`topic.deposit` in the requests API response is always a dict with an `id` key — for this ticket it's a bare string ID, causing an `AttributeError`. Fixed to accept both shapes.

## Test plan
- [x] Added `tools/test_download_zenodo.py` covering `classify_url()` for community-request, me/requests, deposit, record, bare-ID, and unparseable URLs.
- [x] Added `tools/test_download_zenodo_draft.py` covering `is_request_url()` and `resolve_request_to_record_id()` (bare-string topic, dict topic, link fallback).
- [x] `python3 -m unittest discover -s tools -p "test_*.py"` — 43/43 passing.
- [x] Ran `tools/download_zenodo.py` end-to-end (dry-run) against the actual AEAREP-9161 URL with a live `ZENODO_ACCESS_TOKEN` — resolves to record `18940044` and lists its 2 files correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)