### PR TITLE
Fix broken generate_sivacor_partb.sh doc link

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -55,6 +55,7 @@ project:
           children:
             - file: tools/repository/96-90-list_box_files.md
             - file: tools/repository/96-90-get_sivacor_info.md
+            - file: tools/repository/96-90-generate_sivacor_partb.md
             - file: tools/repository/96-90-zenodo_get_ci.md
             - file: tools/repository/96-90-sync-codeocean.md
     - file: automations/index.md


### PR DESCRIPTION
## Summary
- `docs/tools/repository/96-90-generate_sivacor_partb.md` (added in #90) was never added to `docs/myst.yml`'s explicit `toc`, so MyST couldn't resolve a proper slug for it and the index link resolved to a hashed `/build/96-90-generate_sivac-....md` path instead of `/tools/repository/generate-sivacor-partb`
- Add the missing toc entry alongside its sibling repository/cloud tool pages

## Test plan
- [x] `cd docs && myst build --html` and confirmed the route now builds as `/tools/repository/generate-sivacor-partb`, matching sibling pages (e.g. `download-zenodo-draft`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)