### PR TITLE
aea-report-finalize: front-load aea-parse-tags check to Step 0

### DIFF
--- a/.claude/skills/aea-report-finalize/SKILL.md
+++ b/.claude/skills/aea-report-finalize/SKILL.md
@@ -59,10 +59,20 @@ didn't independently check the RA's work.
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 ls -d [0-9]*/ 2>/dev/null   # the openICPSR numbered deposit directory
+command -v aea-parse-tags   # the only tag-consolidation tool this skill uses (Step 4)
 ```
 
 Confirm `REPLICATION.md` exists at `$REPO_ROOT`. If it doesn't, stop — this
 isn't a replication-template repo, or you're in the wrong directory.
+
+`aea-parse-tags` is the only consolidation tool this skill ever runs — there
+is no fallback to a different tool name, and none should be invented. If
+`command -v aea-parse-tags` finds nothing, don't go looking for an older or
+differently-named script (e.g. `aeareq` — retired, see Restrictions) — that
+means the environment is missing a dependency, not that a different tool
+should be substituted. Stop and tell the user `aea-parse-tags` isn't
+installed here, rather than treating its absence as a judgment call to
+surface later at Step 4.
 
 ## Step 1 — Gate: is this already approved, and is a follow-up round underway?
 


### PR DESCRIPTION
## Summary
- Several `aea-report-finalize` finishing-pass runs (6/6 in one batch, aearep-9134/9135/9145/9222/9488/9749) went looking for the retired `aeareq` script during Step 4, found it missing, and stopped to ask the human editor — even though Step 4 already correctly names `aea-parse-tags` as the current tool.
- The skill content itself was already internally consistent (Step 4 and Restrictions both name `aea-parse-tags`, with a "formerly `aeareq`" note) — the failure was that agents acted on stale assumptions before reading that far into the file.
- Adds a `command -v aea-parse-tags` check to Step 0, right where the repo is first located, plus an explicit note not to substitute a different/older tool name if it's missing — so the agent hits the current tool name before it has a chance to go hunting on its own.

## Test plan
- [ ] Re-run `aea-report-finalize` against a repo where `aea-parse-tags` is installed and confirm Step 0 output includes its path, no behavior change downstream.
- [ ] Re-run against a sandboxed/limited-PATH environment where `aea-parse-tags` is absent and confirm the skill stops at Step 0 with a clear message, instead of discovering the gap later at Step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)