### PR TITLE
Record deposit size (MB) on Jira during ingest

### DIFF
--- a/automations/27_update_jira_deposit_size.sh
+++ b/automations/27_update_jira_deposit_size.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# 27_update_jira_deposit_size.sh
+# Compute the size of the just-downloaded deposit and record it (in MB) on
+# the Jira issue's "Deposit size" field. Always overwrites the field, since
+# ingest pipelines can run multiple times.
+#
+# Ticket resolved in order: $jiraticket env var -> config.yml -> openICPSR directory detection.
+#
+# Usage: 27_update_jira_deposit_size.sh <project-dir>
+#   project-dir  Directory the deposit was unpacked into (e.g. $projectID).
+#
+# Must run before the envelope ZIP (if any) is moved out of the current
+# directory (e.g. before "mv *.zip cache/"), so tools/jira_update_deposit_size.py
+# can still see it.
+#
+# Exit code propagates tools/jira_update_deposit_size.py's status (0 success,
+# 1 on failure to update Jira); append `|| true` at the call site if the
+# pipeline should continue regardless.
+
+_project_dir="${1:-}"
+
+if command -v python3.12 &>/dev/null; then
+    PYTHON_CMD="python3.12"
+elif command -v python3 &>/dev/null; then
+    PYTHON_CMD="python3"
+else
+    echo "27_update_jira_deposit_size: no Python 3 found, skipping" >&2
+    exit 0
+fi
+
+if [ -z "$_project_dir" ] || [ ! -d "$_project_dir" ]; then
+    echo "27_update_jira_deposit_size: project directory '$_project_dir' not found, skipping" >&2
+    exit 0
+fi
+
+_jira="${jiraticket:-}"
+echo "27_update_jira_deposit_size: jiraticket from environment: '${_jira}'" >&2
+
+if [ -z "$_jira" ]; then
+    if [ -f config.yml ] && [ -f tools/parse_yaml.sh ]; then
+        . ./tools/parse_yaml.sh
+        _jira=$(parse_yaml config.yml | grep '^jiraticket=' | sed 's/jiraticket=//;s/"//g')
+        echo "27_update_jira_deposit_size: jiraticket from config.yml: '${_jira}'" >&2
+    else
+        echo "27_update_jira_deposit_size: config.yml or parse_yaml.sh not found, skipping config.yml lookup" >&2
+    fi
+fi
+
+if [ -z "$_jira" ]; then
+    _icpsr=$(find . -maxdepth 1 -mindepth 1 -type d -name '[123][0-9][0-9][0-9][0-9][0-9]' 2>/dev/null \
+             | head -1 | xargs -I{} basename {} 2>/dev/null || true)
+    if [ -n "$_icpsr" ]; then
+        echo "27_update_jira_deposit_size: detected openICPSR directory '${_icpsr}', looking up Jira ticket" >&2
+        _jira=$($PYTHON_CMD tools/jira_find_task_by_icpsr.py "$_icpsr" 2>&1) || true
+        echo "27_update_jira_deposit_size: jiraticket from lookup: '${_jira}'" >&2
+    else
+        echo "27_update_jira_deposit_size: no openICPSR directory found" >&2
+    fi
+fi
+
+if [ -z "$_jira" ]; then
+    echo "27_update_jira_deposit_size: no Jira ticket found, skipping" >&2
+    exit 0
+fi
+
+_output=$($PYTHON_CMD tools/jira_update_deposit_size.py "$_jira" "$_project_dir" --yes 2>&1)
+_rc=$?
+echo "$_output" >&2
+[ $_rc -eq 0 ] || echo "27_update_jira_deposit_size: Warning - failed to update Deposit size field" >&2
+
+exit $_rc

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -100,6 +100,7 @@ pipelines:
             - if [ -z "${openICPSRID:-}" ] && { [ ! -z "$ZenodoID" ] || [ ! -z "$jiraticket" ]; }; then zenodo_dir=$(python3 tools/download_zenodo.py ${ZenodoID:+--zenodo-id "$ZenodoID"} ${jiraticket:+--jira-ticket "$jiraticket"} --print-id 2>&1 | tail -1); fi
             - if [ -z "$projectID" ] && [ ! -z "${zenodo_dir:-}" ]; then projectID="$zenodo_dir"; fi
             - ./automations/00_unpack_zip.sh  $projectID
+            - ./automations/27_update_jira_deposit_size.sh $projectID || true
             - mkdir cache
             - if [ ! -z $openICPSRID ]; then mv *.zip cache/; fi
             - if [ ! -z "${zenodo_dir:-}" ]; then zip -rp cache/${projectID}.zip $projectID/* ; fi
@@ -531,6 +532,7 @@ pipelines:
             - chmod a+rx ./automations/*.sh
             - ./automations/00_prepare_aux.sh
             - ./automations/00_unpack_zip.sh  $projectID
+            - ./automations/27_update_jira_deposit_size.sh $projectID || true
             - ./automations/01_check_file_sizes.sh $projectID
             - ./automations/02_create_manifest.sh $projectID
             - ./automations/03_list_data_files.sh $projectID

--- a/tools/jira_update_deposit_size.py
+++ b/tools/jira_update_deposit_size.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Compute the size of a downloaded deposit and record it (in MB) on a Jira
+issue's "Deposit size" custom field. Always overwrites the field - ingest
+pipelines can run multiple times and the field should reflect the latest run.
+
+Usage:
+    python3 jira_update_deposit_size.py <issue-key> <project-dir> [--yes]
+    python3 jira_update_deposit_size.py -h|--help
+
+Arguments:
+    issue-key      Jira issue key (e.g., AEAREP-9354). Bare numbers are
+                    expanded to AEAREP-<n>.
+    project-dir    Directory the deposit was unpacked into.
+
+Size source (checked in this order):
+    1. If the deposit's unpacked directory contains exactly one ZIP file at
+       its top level (the "single inner ZIP" case handled by
+       automations/00_unpack_zip.sh), that ZIP's uncompressed size is used.
+    2. Else, if a ZIP file was downloaded and left at the top level of the
+       current directory (the envelope, before it is moved into cache/),
+       that ZIP's uncompressed size is used.
+    3. Else (no ZIP was downloaded at all, e.g. Zenodo), the on-disk size of
+       project-dir is used.
+
+Options:
+    --yes    Apply the update to Jira. Without this flag, the script only
+             prints what it would do (dry run).
+
+Environment Variables Required (only when --yes is passed):
+    JIRA_USERNAME - Your Jira email address
+    JIRA_API_KEY  - API token from https://id.atlassian.com/manage-profile/security/api-tokens
+
+Output:
+    Prints the computed size and source to stdout. Exit code 0 on success,
+    1 on error.
+"""
+
+import argparse
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+JIRA_SERVER = "https://aeadataeditors.atlassian.net"
+DEPOSIT_SIZE_FIELD_NAME = "Deposit size"
+BYTES_PER_MB = 1024 * 1024
+
+
+def find_top_level_zips(directory):
+    """ZIP files directly inside directory (not recursive), sorted by name."""
+    return sorted(p for p in Path(directory).iterdir() if p.is_file() and p.suffix.lower() == ".zip")
+
+
+def uncompressed_zip_size(zip_path):
+    """Sum of uncompressed file sizes recorded in a ZIP's central directory."""
+    with zipfile.ZipFile(zip_path) as zf:
+        return sum(info.file_size for info in zf.infolist())
+
+
+def on_disk_size(directory):
+    """Sum of file sizes under directory (symlinks excluded)."""
+    total = 0
+    for root, _dirs, files in os.walk(directory):
+        for name in files:
+            path = os.path.join(root, name)
+            if not os.path.islink(path):
+                total += os.path.getsize(path)
+    return total
+
+
+def compute_deposit_size_bytes(project_dir, cwd="."):
+    """
+    Determine the deposit's size in bytes and how it was determined.
+
+    Returns (size_bytes: int, source: str).
+    """
+    inner_zips = find_top_level_zips(project_dir) if os.path.isdir(project_dir) else []
+    if len(inner_zips) == 1:
+        return uncompressed_zip_size(inner_zips[0]), f"single inner ZIP ({inner_zips[0]})"
+
+    envelope_zips = find_top_level_zips(cwd)
+    if envelope_zips:
+        total = sum(uncompressed_zip_size(z) for z in envelope_zips)
+        names = ", ".join(str(z) for z in envelope_zips)
+        return total, f"envelope ZIP ({names})"
+
+    return on_disk_size(project_dir), f"on-disk size of {project_dir}"
+
+
+def normalize_issue_key(key):
+    """Expand a bare issue number to AEAREP-<n>; uppercase any other key as-is."""
+    key = key.strip()
+    if key.isdigit():
+        return f"AEAREP-{key}"
+    return key.upper()
+
+
+def get_jira_client():
+    """Initialize and return an authenticated Jira client, or None if creds/connection fail."""
+    jira_username = os.environ.get("JIRA_USERNAME")
+    jira_api_key = os.environ.get("JIRA_API_KEY")
+
+    if not jira_username or not jira_api_key:
+        print("Error: JIRA_USERNAME and JIRA_API_KEY environment variables must be set", file=sys.stderr)
+        return None
+
+    from jira import JIRA
+
+    try:
+        return JIRA(server=JIRA_SERVER, basic_auth=(jira_username, jira_api_key), options={"verify": True})
+    except Exception as e:
+        print(f"Error: Failed to connect to Jira: {e}", file=sys.stderr)
+        return None
+
+
+def resolve_field_id(jira, field_name):
+    """Look up a custom field's id by its display name, or None if not found."""
+    try:
+        for field in jira.fields():
+            if field["name"] == field_name:
+                return field["id"]
+    except Exception:
+        pass
+    return None
+
+
+def update_deposit_size_field(jira, issue_key, size_mb, field_name=DEPOSIT_SIZE_FIELD_NAME):
+    """Unconditionally overwrite the Deposit size field on issue_key with size_mb."""
+    field_id = resolve_field_id(jira, field_name)
+    if field_id is None:
+        raise RuntimeError(f"Jira field '{field_name}' not found")
+
+    issue = jira.issue(issue_key)
+    issue.update(fields={field_id: size_mb})
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="jira_update_deposit_size.py",
+        description="Compute deposit size and record it (in MB) on Jira's 'Deposit size' field.",
+    )
+    parser.add_argument("issue_key")
+    parser.add_argument("project_dir")
+    parser.add_argument("--yes", action="store_true", help="Apply the update to Jira (default is a dry run)")
+    args = parser.parse_args(argv)
+
+    if not os.path.isdir(args.project_dir):
+        print(f"Error: project directory not found: {args.project_dir}", file=sys.stderr)
+        return 1
+
+    size_bytes, source = compute_deposit_size_bytes(args.project_dir)
+    size_mb = round(size_bytes / BYTES_PER_MB, 2)
+
+    print(f"Deposit size: {size_mb} MB (source: {source})")
+
+    if not args.yes:
+        print("Dry run (pass --yes to apply). Would set Jira's Deposit size field to:", size_mb)
+        return 0
+
+    jira = get_jira_client()
+    if jira is None:
+        return 1
+
+    issue_key = normalize_issue_key(args.issue_key)
+
+    try:
+        update_deposit_size_field(jira, issue_key, size_mb)
+    except Exception as e:
+        print(f"Error: Failed to update {issue_key}: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Updated {issue_key} Deposit size to {size_mb} MB")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_jira_update_deposit_size.py
+++ b/tools/test_jira_update_deposit_size.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for jira_update_deposit_size.py. Run: python3 tools/test_jira_update_deposit_size.py"""
+import os
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import jira_update_deposit_size as juds
+
+
+def _make_zip(path, file_sizes):
+    """Create a ZIP at path whose members have the given uncompressed sizes (bytes)."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, size in file_sizes.items():
+            zf.writestr(name, b"x" * size)
+
+
+class TestComputeDepositSizeBytes(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.cwd = self.root / "cwd"
+        self.project_dir = self.cwd / "12345"
+        self.project_dir.mkdir(parents=True)
+
+    def test_single_inner_zip_wins_over_envelope(self):
+        _make_zip(self.cwd / "12345.zip", {"a.txt": 100})  # envelope, should be ignored
+        _make_zip(self.project_dir / "data.zip", {"b.txt": 10, "c.txt": 20})
+
+        size, source = juds.compute_deposit_size_bytes(str(self.project_dir), cwd=str(self.cwd))
+
+        self.assertEqual(size, 30)
+        self.assertIn("single inner ZIP", source)
+
+    def test_envelope_zip_used_when_no_single_inner_zip(self):
+        _make_zip(self.cwd / "12345.zip", {"a.txt": 100, "b.txt": 50})
+
+        size, source = juds.compute_deposit_size_bytes(str(self.project_dir), cwd=str(self.cwd))
+
+        self.assertEqual(size, 150)
+        self.assertIn("envelope ZIP", source)
+
+    def test_envelope_ignored_when_multiple_inner_zips(self):
+        _make_zip(self.cwd / "12345.zip", {"a.txt": 999})
+        _make_zip(self.project_dir / "part1.zip", {"x.txt": 5})
+        _make_zip(self.project_dir / "part2.zip", {"y.txt": 7})
+
+        size, source = juds.compute_deposit_size_bytes(str(self.project_dir), cwd=str(self.cwd))
+
+        self.assertEqual(size, 999)
+        self.assertIn("envelope ZIP", source)
+
+    def test_on_disk_size_when_no_zip_anywhere(self):
+        (self.project_dir / "data.csv").write_bytes(b"x" * 42)
+        sub = self.project_dir / "sub"
+        sub.mkdir()
+        (sub / "more.csv").write_bytes(b"y" * 8)
+
+        size, source = juds.compute_deposit_size_bytes(str(self.project_dir), cwd=str(self.cwd))
+
+        self.assertEqual(size, 50)
+        self.assertIn("on-disk size", source)
+
+
+class TestNormalizeIssueKey(unittest.TestCase):
+    def test_bare_number_gets_prefixed(self):
+        self.assertEqual(juds.normalize_issue_key("9603"), "AEAREP-9603")
+
+    def test_prefixed_key_is_uppercased(self):
+        self.assertEqual(juds.normalize_issue_key("train-2000"), "TRAIN-2000")
+
+
+class TestResolveFieldId(unittest.TestCase):
+    def test_finds_field_by_name(self):
+        jira = MagicMock()
+        jira.fields.return_value = [
+            {"id": "customfield_10028", "name": "Software used"},
+            {"id": "customfield_10099", "name": "Deposit size"},
+        ]
+
+        self.assertEqual(juds.resolve_field_id(jira, "Deposit size"), "customfield_10099")
+
+    def test_returns_none_when_not_found(self):
+        jira = MagicMock()
+        jira.fields.return_value = [{"id": "customfield_10028", "name": "Software used"}]
+
+        self.assertIsNone(juds.resolve_field_id(jira, "Deposit size"))
+
+
+class TestUpdateDepositSizeField(unittest.TestCase):
+    def test_overwrites_unconditionally(self):
+        jira = MagicMock()
+        jira.fields.return_value = [{"id": "customfield_10099", "name": "Deposit size"}]
+        issue = MagicMock()
+        jira.issue.return_value = issue
+
+        juds.update_deposit_size_field(jira, "AEAREP-1", 12.34)
+
+        issue.update.assert_called_once_with(fields={"customfield_10099": 12.34})
+
+    def test_raises_when_field_missing(self):
+        jira = MagicMock()
+        jira.fields.return_value = []
+
+        with self.assertRaises(RuntimeError):
+            juds.update_deposit_size_field(jira, "AEAREP-1", 12.34)
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.project_dir = Path(self._tmp.name) / "12345"
+        self.project_dir.mkdir()
+        (self.project_dir / "data.csv").write_bytes(b"x" * (2 * juds.BYTES_PER_MB))
+
+    def test_dry_run_without_yes_returns_0_and_makes_no_jira_call(self):
+        rc = juds.main([str(1), str(self.project_dir)])
+        self.assertEqual(rc, 0)
+
+    def test_missing_project_dir_returns_1(self):
+        rc = juds.main(["1", str(self.project_dir / "does-not-exist")])
+        self.assertEqual(rc, 1)
+
+    def test_yes_without_credentials_returns_1(self):
+        env = dict(os.environ)
+        os.environ.pop("JIRA_USERNAME", None)
+        os.environ.pop("JIRA_API_KEY", None)
+        try:
+            rc = juds.main(["1", str(self.project_dir), "--yes"])
+        finally:
+            os.environ.clear()
+            os.environ.update(env)
+        self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `automations/27_update_jira_deposit_size.sh` + `tools/jira_update_deposit_size.py`, following the same thin-wrapper/tool paradigm as `26_update_jira_software.sh`/`jira_update_software.py`, to compute the downloaded deposit's size and write it (in MB) to Jira's "Deposit size" custom field.
- Size source, in priority order:
  1. Uncompressed size of a single inner ZIP, when the deposit's unpacked directory contains exactly one (mirrors `00_unpack_zip.sh`'s own "up to 5 inner ZIPs" detection).
  2. Else the uncompressed size of the downloaded envelope ZIP (found at the top level of the working directory).
  3. Else the on-disk size of the unpacked directory — covers deposits where no ZIP is downloaded at all (e.g. Zenodo).
- The field is **always overwritten unconditionally** (no diff/union against the existing value) since ingest pipelines can be re-run.
- Jira field id is resolved dynamically by field name ("Deposit size") rather than hardcoded, matching `jira_get_info.py`'s pattern.
- Wired into `bitbucket-pipelines.yml` right after `00_unpack_zip.sh` in the two primary download steps (`1-populate-from-icpsr` → Download, `w-big-populate-from-icpsr` → Download and commit), before any envelope ZIP gets moved into `cache/`. Not added to the other `00_unpack_zip.sh` call sites (parallel language-scanner steps), since those just re-extract cached artifacts per-language in separate containers rather than performing the actual download.

## Test plan
- [x] `python3 tools/test_jira_update_deposit_size.py` — 13 new unit tests covering all three size-source branches, field resolution, unconditional overwrite, and CLI error paths.
- [x] Ran the full existing `tools/test_*.py` suite — no regressions.
- [x] Manually ran `automations/27_update_jira_deposit_size.sh` end-to-end (dry paths + against the real Jira API, read-only field lookup) to confirm the "Deposit size" field name/id resolves correctly.
- [x] `bash -n` syntax check on the new shell script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)