### PR TITLE
Replace free-text Software used field with checkbox + other-text structure

### DIFF
--- a/automations/26_update_jira_software.sh
+++ b/automations/26_update_jira_software.sh
@@ -2,8 +2,9 @@
 # 26_update_jira_software.sh
 # Detect software used (Stata, R, Python, etc.) from the program files listed
 # by 04_list_program_files.sh, and add any newly-identified software to the
-# Jira issue's "Software used" field (customfield_10028). Never removes
-# existing values.
+# Jira issue's "Software used" checkbox field (Stata/MATLAB/R/Python/SAS/Julia),
+# falling back to the "Software used (other)" text field for anything that
+# isn't one of those checkbox options. Never removes existing values.
 #
 # Ticket resolved in order: $jiraticket env var -> config.yml -> openICPSR directory detection.
 #
@@ -14,7 +15,7 @@
 # Stdout carries only the "Software detected: ..." line (if any software was
 # found), so a caller can capture it and forward it to 70_publish_comment.sh
 # as a durable fallback for cases where the "Software used" field write fails
-# (e.g. customfield_10028 missing from an issue's screen). All other
+# (e.g. one of the fields missing from an issue's screen). All other
 # diagnostics go to stderr.
 #
 # Exit code propagates tools/jira_update_software.py's status (0 success,

--- a/tools/jira_migrate_software_field.py
+++ b/tools/jira_migrate_software_field.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Migrate values from the retired "Software used (v1)" labels field
+(customfield_10028) into the new "Software used" checkboxes field and
+"Software used (other)" text field, for every AEAREP issue that has v1 set.
+
+Normalized values that match one of the new checkbox field's configured
+options are written there; anything else is appended (deduped) to the
+"other" text field. "Software used (v1)" itself is never modified.
+
+Usage:
+    python3 jira_migrate_software_field.py [--yes] [--issue KEY ...]
+    python3 jira_migrate_software_field.py -h|--help
+
+Options:
+    --yes           Apply updates to Jira. Without this flag, the script
+                     only prints what it would do (dry run).
+    --issue KEY     Limit migration to specific issue key(s) (repeatable).
+                     Default: every AEAREP issue with "Software used (v1)" set.
+
+Environment Variables Required (only when --yes is passed):
+    JIRA_USERNAME - Your Jira email address
+    JIRA_API_KEY  - API token from https://id.atlassian.com/manage-profile/security/api-tokens
+
+Output:
+    Per-issue before/after summary, then a final tally of issues touched
+    and any raw values that didn't normalize to a known canonical name
+    (flagged for manual review, still recorded verbatim in "other").
+    Exit code 0 on success (including a no-op dry run), 1 on error.
+"""
+
+import argparse
+import os
+import sys
+
+JIRA_SERVER = "https://aeadataeditors.atlassian.net"
+V1_FIELD_NAME = "Software used (v1)"
+CHECKBOX_FIELD_NAME = "Software used"
+OTHER_FIELD_NAME = "Software used (other)"
+
+# Stray casing variants observed in the live v1 field beyond what the
+# extension/filename tables themselves imply canonical names for.
+EXTRA_ALIASES = {
+    "matlab": "MATLAB",
+    "stata": "Stata",
+    "python": "Python",
+    "r": "R",
+    "sas": "SAS",
+    "julia": "Julia",
+}
+
+
+def normalize(raw_value, alias_map):
+    key = raw_value.strip().lower()
+    return alias_map.get(key, raw_value.strip())
+
+
+def get_jira_client():
+    jira_username = os.environ.get("JIRA_USERNAME")
+    jira_api_key = os.environ.get("JIRA_API_KEY")
+
+    if not jira_username or not jira_api_key:
+        print("Error: JIRA_USERNAME and JIRA_API_KEY environment variables must be set", file=sys.stderr)
+        return None
+
+    from jira import JIRA
+
+    try:
+        return JIRA(server=JIRA_SERVER, basic_auth=(jira_username, jira_api_key), options={"verify": True})
+    except Exception as e:
+        print(f"Error: Failed to connect to Jira: {e}", file=sys.stderr)
+        return None
+
+
+def resolve_fields(jira):
+    """Return (v1_field_id, checkbox_field_id, other_field_id, checkbox_options: set[str])."""
+    field_map = {field["name"]: field["id"] for field in jira.fields()}
+
+    v1_id = field_map.get(V1_FIELD_NAME)
+    checkbox_id = field_map.get(CHECKBOX_FIELD_NAME)
+    other_id = field_map.get(OTHER_FIELD_NAME)
+
+    checkbox_options = fetch_checkbox_options(jira, checkbox_id) if checkbox_id else set()
+
+    return v1_id, checkbox_id, other_id, checkbox_options
+
+
+def fetch_checkbox_options(jira, checkbox_field_id):
+    """Fetch the checkbox field's configured option labels via a sample issue's editmeta."""
+    jql = f"project = AEAREP ORDER BY key DESC"
+    issues = jira.enhanced_search_issues(jql, maxResults=1, fields=checkbox_field_id)
+    if not issues:
+        return set()
+    meta = jira.editmeta(issues[0])
+    field_meta = meta.get("fields", {}).get(checkbox_field_id)
+    if not field_meta:
+        return set()
+    return {opt["value"] for opt in field_meta.get("allowedValues", [])}
+
+
+def alias_map_from_options(checkbox_options):
+    alias_map = {name.lower(): name for name in checkbox_options}
+    alias_map.update({k: v for k, v in EXTRA_ALIASES.items() if v in checkbox_options})
+    return alias_map
+
+
+def fetch_issues_with_v1(jira, v1_field_id, checkbox_field_id, other_field_id, issue_keys=None):
+    if issue_keys:
+        jql = f"key in ({', '.join(issue_keys)})"
+    else:
+        cf_number = v1_field_id.replace("customfield_", "")
+        jql = f"project = AEAREP AND cf[{cf_number}] is not EMPTY ORDER BY key"
+    fields = [v1_field_id, checkbox_field_id, other_field_id]
+    return jira.enhanced_search_issues(jql, maxResults=False, fields=fields)
+
+
+def plan_migration(v1_values, checkbox_options, alias_map, existing_other):
+    """Return (checkbox_values: set[str], other_values: set[str], unrecognized: set[str])."""
+    checkbox_values = set()
+    other_values = set(v.strip() for v in (existing_other or "").split(",") if v.strip())
+    unrecognized = set()
+    for raw in v1_values:
+        canonical = normalize(raw, alias_map)
+        if canonical in checkbox_options:
+            checkbox_values.add(canonical)
+        else:
+            other_values.add(canonical)
+            if canonical.lower() not in alias_map and canonical not in checkbox_options:
+                unrecognized.add(raw.strip())
+    return checkbox_values, other_values, unrecognized
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="jira_migrate_software_field.py",
+        description="Migrate 'Software used (v1)' values into the new checkbox and 'other' fields.",
+    )
+    parser.add_argument("--yes", action="store_true", help="Apply updates to Jira (default is a dry run)")
+    parser.add_argument("--issue", action="append", default=None, help="Limit to specific issue key(s)")
+    args = parser.parse_args(argv)
+
+    jira = get_jira_client()
+    if jira is None:
+        return 1
+
+    v1_id, checkbox_id, other_id, checkbox_options = resolve_fields(jira)
+    if not v1_id:
+        print(f"Error: could not find field '{V1_FIELD_NAME}'", file=sys.stderr)
+        return 1
+    if not checkbox_id:
+        print(f"Error: could not find field '{CHECKBOX_FIELD_NAME}'", file=sys.stderr)
+        return 1
+    if not other_id:
+        print(f"Error: could not find field '{OTHER_FIELD_NAME}'", file=sys.stderr)
+        return 1
+    if not checkbox_options:
+        print(f"Error: could not read allowed options for '{CHECKBOX_FIELD_NAME}'", file=sys.stderr)
+        return 1
+
+    alias_map = alias_map_from_options(checkbox_options)
+
+    issue_keys = [k.upper() for k in args.issue] if args.issue else None
+    issues = fetch_issues_with_v1(jira, v1_id, checkbox_id, other_id, issue_keys)
+
+    touched = 0
+    all_unrecognized = {}
+
+    for issue in issues:
+        v1_values = getattr(issue.fields, v1_id, None) or []
+        if not v1_values:
+            continue
+
+        current_checkbox = {opt.value for opt in (getattr(issue.fields, checkbox_id, None) or [])}
+        current_other = getattr(issue.fields, other_id, None) or ""
+
+        checkbox_values, other_values, unrecognized = plan_migration(
+            v1_values, checkbox_options, alias_map, current_other
+        )
+
+        new_checkbox = current_checkbox | checkbox_values
+        new_other = ", ".join(sorted(other_values))
+
+        changed = new_checkbox != current_checkbox or new_other != current_other
+        if not changed:
+            continue
+
+        touched += 1
+        for raw in unrecognized:
+            all_unrecognized[raw] = all_unrecognized.get(raw, 0) + 1
+
+        print(f"{issue.key}: v1={sorted(v1_values)}")
+        if new_checkbox != current_checkbox:
+            print(f"  checkbox: {sorted(current_checkbox)} -> {sorted(new_checkbox)}")
+        if new_other != current_other:
+            print(f"  other: {current_other!r} -> {new_other!r}")
+
+        if args.yes:
+            fields = {}
+            if new_checkbox != current_checkbox:
+                fields[checkbox_id] = [{"value": v} for v in sorted(new_checkbox)]
+            if new_other != current_other:
+                fields[other_id] = new_other
+            try:
+                issue.update(fields=fields)
+            except Exception as e:
+                print(f"  Error: failed to update {issue.key}: {e}", file=sys.stderr)
+
+    print()
+    print(f"{'Applied' if args.yes else 'Would apply'} changes to {touched} issue(s).")
+    if all_unrecognized:
+        print("Raw values that didn't normalize to a checkbox option (recorded in 'other' verbatim):")
+        for raw, count in sorted(all_unrecognized.items(), key=lambda kv: (-kv[1], kv[0])):
+            print(f"  {raw!r} ({count})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/jira_software_field_report.py
+++ b/tools/jira_software_field_report.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Report live usage frequency of the "Software used" Jira field (customfield_10028)
+across all AEAREP issues, to decide the option list for the new checkbox field
+that will replace it.
+
+Usage:
+    python3 jira_software_field_report.py [--threshold PERCENT]
+    python3 jira_software_field_report.py -h|--help
+
+Options:
+    --threshold PERCENT   Minimum percent of tickets-with-field-set a value
+                          must reach to be listed as a checkbox candidate
+                          (default: 5).
+
+Environment Variables Required:
+    JIRA_USERNAME - Your Jira email address
+    JIRA_API_KEY  - API token from https://id.atlassian.com/manage-profile/security/api-tokens
+
+Output:
+    Prints a frequency table (sorted by declining count), split into
+    checkbox candidates (>= threshold) and rare values (< threshold), plus
+    any raw values that don't normalize to a known canonical software name.
+    Read-only: makes no changes to Jira. Exit code 0 on success, 1 on error.
+"""
+
+import argparse
+import csv
+import os
+import sys
+from pathlib import Path
+
+JIRA_SERVER = "https://aeadataeditors.atlassian.net"
+FIELD_NAME = "Software used"
+
+DEFAULT_EXT_LOOKUP = Path(__file__).resolve().parent / "software-extensions.csv"
+DEFAULT_NAME_LOOKUP = Path(__file__).resolve().parent / "software-filenames.csv"
+
+# Stray casing variants observed in the live field beyond what the
+# extension/filename tables themselves imply canonical names for.
+EXTRA_ALIASES = {
+    "matlab": "MATLAB",
+    "stata": "Stata",
+    "python": "Python",
+    "r": "R",
+    "sas": "SAS",
+    "julia": "Julia",
+    "dynare": "Dynare",
+    "unknown": "Unknown",
+}
+
+
+def load_canonical_names(ext_csv, name_csv):
+    """Collect the set of canonical software names this repo already recognizes."""
+    names = set()
+    for csv_path in (ext_csv, name_csv):
+        with open(csv_path, newline="") as f:
+            reader = csv.reader(f)
+            next(reader, None)  # header
+            for row in reader:
+                if row:
+                    names.add(row[1].strip())
+    return names
+
+
+def build_alias_map(canonical_names):
+    """Map lower-cased name -> canonical name, for normalizing raw field values."""
+    alias_map = {name.lower(): name for name in canonical_names}
+    alias_map.update(EXTRA_ALIASES)
+    return alias_map
+
+
+def normalize(raw_value, alias_map):
+    """Return (canonical_name, was_recognized: bool)."""
+    key = raw_value.strip().lower()
+    if key in alias_map:
+        return alias_map[key], True
+    return raw_value.strip(), False
+
+
+def get_jira_client():
+    jira_username = os.environ.get("JIRA_USERNAME")
+    jira_api_key = os.environ.get("JIRA_API_KEY")
+
+    if not jira_username or not jira_api_key:
+        print("Error: JIRA_USERNAME and JIRA_API_KEY environment variables must be set", file=sys.stderr)
+        return None
+
+    from jira import JIRA
+
+    try:
+        return JIRA(server=JIRA_SERVER, basic_auth=(jira_username, jira_api_key), options={"verify": True})
+    except Exception as e:
+        print(f"Error: Failed to connect to Jira: {e}", file=sys.stderr)
+        return None
+
+
+def resolve_field_id(jira, field_name):
+    for field in jira.fields():
+        if field["name"] == field_name:
+            return field["id"]
+    return None
+
+
+def fetch_field_values(jira, field_id):
+    """Yield the raw label list of `field_id` for every AEAREP issue that has it set."""
+    cf_number = field_id.replace("customfield_", "")
+    jql = f'project = AEAREP AND cf[{cf_number}] is not EMPTY ORDER BY key'
+    issues = jira.enhanced_search_issues(jql, maxResults=False, fields=field_id)
+    for issue in issues:
+        values = getattr(issue.fields, field_id, None) or []
+        yield issue.key, values
+
+
+def tally(jira, field_id, alias_map):
+    """Return (counts: dict[name,int], tickets_with_field: int, unrecognized: dict[str,int])."""
+    counts = {}
+    unrecognized = {}
+    tickets_with_field = 0
+    for _issue_key, values in fetch_field_values(jira, field_id):
+        if not values:
+            continue
+        tickets_with_field += 1
+        for raw in values:
+            canonical, recognized = normalize(raw, alias_map)
+            counts[canonical] = counts.get(canonical, 0) + 1
+            if not recognized:
+                unrecognized[raw] = unrecognized.get(raw, 0) + 1
+    return counts, tickets_with_field, unrecognized
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="jira_software_field_report.py",
+        description="Report live usage frequency of the 'Software used' Jira field.",
+    )
+    parser.add_argument("--threshold", type=float, default=5.0, help="Checkbox-candidate cutoff, percent (default: 5)")
+    parser.add_argument("--lookup-ext", default=str(DEFAULT_EXT_LOOKUP))
+    parser.add_argument("--lookup-name", default=str(DEFAULT_NAME_LOOKUP))
+    args = parser.parse_args(argv)
+
+    jira = get_jira_client()
+    if jira is None:
+        return 1
+
+    field_id = resolve_field_id(jira, FIELD_NAME)
+    if field_id is None:
+        print(f"Error: could not find a field named '{FIELD_NAME}'", file=sys.stderr)
+        return 1
+
+    canonical_names = load_canonical_names(args.lookup_ext, args.lookup_name)
+    alias_map = build_alias_map(canonical_names)
+
+    counts, tickets_with_field, unrecognized = tally(jira, field_id, alias_map)
+
+    if tickets_with_field == 0:
+        print(f"No AEAREP issues have '{FIELD_NAME}' ({field_id}) set.")
+        return 0
+
+    print(f"Field: {FIELD_NAME} ({field_id})")
+    print(f"Tickets with field set: {tickets_with_field}")
+    print()
+
+    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    checkbox_candidates = []
+    rare = []
+    print(f"{'Value':<15} {'Count':>6} {'% of tickets':>13}  Candidate")
+    for name, count in ranked:
+        pct = 100.0 * count / tickets_with_field
+        is_candidate = pct >= args.threshold
+        (checkbox_candidates if is_candidate else rare).append((name, count, pct))
+        label = "checkbox" if is_candidate else "other (rare)"
+        print(f"{name:<15} {count:>6} {pct:>12.1f}%  {label}")
+
+    print()
+    print(f"Checkbox candidates (>= {args.threshold}%), in declining-frequency order:")
+    for name, count, pct in checkbox_candidates:
+        print(f"  {name} ({count}, {pct:.1f}%)")
+
+    print()
+    print(f"Rare values (< {args.threshold}%, would land in 'other'):")
+    for name, count, pct in rare:
+        print(f"  {name} ({count}, {pct:.1f}%)")
+
+    if unrecognized:
+        print()
+        print("Raw values that did not normalize to a known canonical name (review for typos/new tools):")
+        for raw, count in sorted(unrecognized.items(), key=lambda kv: (-kv[1], kv[0])):
+            print(f"  {raw!r} ({count})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/jira_update_software.py
+++ b/tools/jira_update_software.py
@@ -2,7 +2,9 @@
 """
 Detect the software used in a deposit from a programs-metadata.csv (produced
 by automations/04_list_program_files.sh) and update a Jira issue's
-"Software used" field (customfield_10028) with any newly-identified names.
+"Software used" checkbox field with any newly-identified names, plus the
+"Software used (other)" text field for anything that isn't a checkbox
+option.
 
 Usage:
     python3 jira_update_software.py <issue-key> <metadata-csv> [--project-dir DIR] [--yes]
@@ -42,19 +44,16 @@ import time
 from pathlib import Path
 
 JIRA_SERVER = "https://aeadataeditors.atlassian.net"
-SOFTWARE_FIELD = "customfield_10028"
+CHECKBOX_FIELD_NAME = "Software used"
+OTHER_FIELD_NAME = "Software used (other)"
 
-# Jira Cloud intermittently rejects a field write with this exact message even
-# when the field is genuinely on the issue's edit screen (observed on AEAREP
-# tickets of varying age, both touched and untouched) - a bare retry after a
-# short delay has always cleared it in testing. Retry only this specific
-# signature; any other error is a real failure and is not retried.
+# Jira Cloud intermittently rejects a field write with a "not on the
+# appropriate screen" 400 even when the field is genuinely on the issue's
+# edit screen (observed on AEAREP tickets of varying age, both touched and
+# untouched) - a bare retry after a short delay has always cleared it in
+# testing. Retry only this specific signature; any other error is a real
+# failure and is not retried.
 RETRY_DELAYS_SECONDS = (2, 5, 10)
-
-# The field's configured default value for newly created issues. Once real
-# software is detected, this placeholder is removed rather than left
-# alongside the real values.
-UNKNOWN_LABEL = "Unknown"
 
 DEFAULT_EXT_LOOKUP = Path(__file__).resolve().parent / "software-extensions.csv"
 DEFAULT_NAME_LOOKUP = Path(__file__).resolve().parent / "software-filenames.csv"
@@ -186,49 +185,98 @@ def get_jira_client():
         return None
 
 
-def _is_transient_screen_error(exc):
-    """True if exc is the intermittent Jira Cloud 'field not on screen' 400 for this field."""
+def resolve_fields(jira):
+    """Return (checkbox_field_id, other_field_id) by display name."""
+    field_map = {field["name"]: field["id"] for field in jira.fields()}
+    checkbox_id = field_map.get(CHECKBOX_FIELD_NAME)
+    other_id = field_map.get(OTHER_FIELD_NAME)
+    if not checkbox_id:
+        raise RuntimeError(f"Could not find field '{CHECKBOX_FIELD_NAME}'")
+    if not other_id:
+        raise RuntimeError(f"Could not find field '{OTHER_FIELD_NAME}'")
+    return checkbox_id, other_id
+
+
+def fetch_checkbox_options(jira, issue, checkbox_field_id):
+    """Fetch the checkbox field's configured option labels via the issue's editmeta."""
+    meta = jira.editmeta(issue)
+    field_meta = meta.get("fields", {}).get(checkbox_field_id)
+    if not field_meta:
+        return set()
+    return {opt["value"] for opt in field_meta.get("allowedValues", [])}
+
+
+def _is_transient_screen_error(exc, field_ids):
+    """True if exc is the intermittent Jira Cloud 'field not on screen' 400 for one of field_ids."""
     text = getattr(exc, "text", None) or ""
     return (
         getattr(exc, "status_code", None) == 400
-        and SOFTWARE_FIELD in text
+        and any(field_id in text for field_id in field_ids)
         and "not on the appropriate screen" in text
     )
 
 
 def update_software_field(jira, issue_key, new_software, retry_delays=RETRY_DELAYS_SECONDS, sleep=time.sleep):
     """
-    Union new_software into the issue's current Software used labels,
-    dropping the UNKNOWN_LABEL placeholder now that real software is known,
-    and update Jira only if that changes the set.
+    Partition new_software into checkbox-valid and invalid (not a configured
+    checkbox option), union the valid ones into the checkbox field and the
+    invalid ones into the "other" text field, and update Jira only if that
+    changes either field. When invalid values are recorded, also posts an
+    issue comment noting they weren't a checkbox option.
 
     Retries the write on Jira's intermittent transient screen-validation
     error (see RETRY_DELAYS_SECONDS), sleeping between attempts via `sleep`
     (overridable for tests). Any other error, or exhausting all retries,
     propagates to the caller.
 
-    Returns (updated: bool, final_set: set[str], added: set[str]).
+    Returns (updated: bool, final_checkbox: set[str], added_checkbox: set[str], invalid: set[str]).
     """
     from jira.exceptions import JIRAError
 
+    checkbox_id, other_id = resolve_fields(jira)
     issue = jira.issue(issue_key)
-    current = getattr(issue.fields, SOFTWARE_FIELD, None) or []
-    current_set = set(current)
-    final_set = (current_set - {UNKNOWN_LABEL}) | set(new_software)
-    added = final_set - current_set
-    updated = final_set != current_set
+
+    checkbox_options = fetch_checkbox_options(jira, issue, checkbox_id)
+    current_checkbox = {opt.value for opt in (getattr(issue.fields, checkbox_id, None) or [])}
+    current_other = getattr(issue.fields, other_id, None) or ""
+    current_other_values = {v.strip() for v in current_other.split(",") if v.strip()}
+
+    valid = {name for name in new_software if name in checkbox_options}
+    invalid = {name for name in new_software if name not in checkbox_options}
+
+    final_checkbox = current_checkbox | valid
+    final_other_values = current_other_values | invalid
+    final_other = ", ".join(sorted(final_other_values))
+
+    added_checkbox = final_checkbox - current_checkbox
+    updated = final_checkbox != current_checkbox or final_other != current_other
+
     if updated:
+        fields = {}
+        if final_checkbox != current_checkbox:
+            fields[checkbox_id] = [{"value": v} for v in sorted(final_checkbox)]
+        if final_other != current_other:
+            fields[other_id] = final_other
+
         remaining_delays = list(retry_delays)
         while True:
             try:
-                issue.update(fields={SOFTWARE_FIELD: sorted(final_set)})
+                issue.update(fields=fields)
                 break
             except JIRAError as e:
-                if remaining_delays and _is_transient_screen_error(e):
+                if remaining_delays and _is_transient_screen_error(e, (checkbox_id, other_id)):
                     sleep(remaining_delays.pop(0))
                     continue
                 raise
-    return updated, final_set, added
+
+        if invalid:
+            jira.add_comment(
+                issue,
+                f"Detected software not in the '{CHECKBOX_FIELD_NAME}' checkbox options, "
+                f"recorded in '{OTHER_FIELD_NAME}' instead: {', '.join(sorted(invalid))}",
+            )
+
+    return updated, final_checkbox, added_checkbox, invalid
 
 
 def main(argv=None):
@@ -279,14 +327,16 @@ def main(argv=None):
     issue_key = normalize_issue_key(args.issue_key)
 
     try:
-        updated, final_set, added = update_software_field(jira, issue_key, found)
+        updated, final_checkbox, added_checkbox, invalid = update_software_field(jira, issue_key, found)
     except Exception as e:
         print(f"Error: Failed to update {issue_key}: {e}", file=sys.stderr)
         return 1
 
     if updated:
-        added_note = f"added {', '.join(sorted(added))}" if added else f"replaced '{UNKNOWN_LABEL}'"
-        print(f"Updated {issue_key} Software used: {added_note} (now: {', '.join(sorted(final_set))})")
+        note = f"added {', '.join(sorted(added_checkbox))}" if added_checkbox else "no new checkbox values"
+        print(f"Updated {issue_key} Software used: {note} (now: {', '.join(sorted(final_checkbox))})")
+        if invalid:
+            print(f"  Also recorded in '{OTHER_FIELD_NAME}' and commented: {', '.join(sorted(invalid))}")
     else:
         print(f"{issue_key} Software used already contains all detected software; no update needed.")
     return 0

--- a/tools/test_jira_update_software.py
+++ b/tools/test_jira_update_software.py
@@ -162,101 +162,121 @@ class TestNormalizeIssueKey(unittest.TestCase):
         self.assertEqual(jus.normalize_issue_key("AEAREP-9603"), "AEAREP-9603")
 
 
+CHECKBOX_FIELD_ID = "customfield_10553"
+OTHER_FIELD_ID = "customfield_10554"
+CHECKBOX_OPTIONS = {"Stata", "MATLAB", "R", "Python", "SAS", "Julia"}
+
+
+class _Option:
+    def __init__(self, value):
+        self.value = value
+
+
 class TestUpdateSoftwareField(unittest.TestCase):
-    def _mock_issue(self, current_labels):
+    def _mock_jira(self, current_checkbox, current_other=None, checkbox_options=CHECKBOX_OPTIONS):
+        jira = MagicMock()
+        jira.fields.return_value = [
+            {"name": jus.CHECKBOX_FIELD_NAME, "id": CHECKBOX_FIELD_ID},
+            {"name": jus.OTHER_FIELD_NAME, "id": OTHER_FIELD_ID},
+        ]
+        jira.editmeta.return_value = {
+            "fields": {
+                CHECKBOX_FIELD_ID: {"allowedValues": [{"value": v} for v in checkbox_options]},
+            }
+        }
         issue = MagicMock()
-        setattr(issue.fields, jus.SOFTWARE_FIELD, current_labels)
-        return issue
+        setattr(issue.fields, CHECKBOX_FIELD_ID, [_Option(v) for v in current_checkbox])
+        setattr(issue.fields, OTHER_FIELD_ID, current_other)
+        jira.issue.return_value = issue
+        return jira, issue
 
     def test_adds_new_software_to_empty_field(self):
-        jira = MagicMock()
-        issue = self._mock_issue([])
-        jira.issue.return_value = issue
+        jira, issue = self._mock_jira([])
 
-        updated, final_set, added = jus.update_software_field(jira, "AEAREP-1", {"Stata"})
+        updated, final_checkbox, added, invalid = jus.update_software_field(jira, "AEAREP-1", {"Stata"})
 
         self.assertTrue(updated)
-        self.assertEqual(final_set, {"Stata"})
+        self.assertEqual(final_checkbox, {"Stata"})
         self.assertEqual(added, {"Stata"})
-        issue.update.assert_called_once_with(fields={jus.SOFTWARE_FIELD: ["Stata"]})
+        self.assertEqual(invalid, set())
+        issue.update.assert_called_once_with(fields={CHECKBOX_FIELD_ID: [{"value": "Stata"}]})
 
     def test_unions_with_existing_and_dedupes(self):
-        jira = MagicMock()
-        issue = self._mock_issue(["Stata"])
-        jira.issue.return_value = issue
+        jira, issue = self._mock_jira(["Stata"])
 
-        updated, final_set, added = jus.update_software_field(jira, "AEAREP-1", {"Stata", "Python"})
+        updated, final_checkbox, added, invalid = jus.update_software_field(jira, "AEAREP-1", {"Stata", "Python"})
 
         self.assertTrue(updated)
-        self.assertEqual(final_set, {"Stata", "Python"})
+        self.assertEqual(final_checkbox, {"Stata", "Python"})
         self.assertEqual(added, {"Python"})
-        issue.update.assert_called_once_with(fields={jus.SOFTWARE_FIELD: ["Python", "Stata"]})
+        issue.update.assert_called_once_with(
+            fields={CHECKBOX_FIELD_ID: [{"value": "Python"}, {"value": "Stata"}]}
+        )
 
     def test_no_update_when_nothing_new(self):
-        jira = MagicMock()
-        issue = self._mock_issue(["Stata", "Python"])
-        jira.issue.return_value = issue
+        jira, issue = self._mock_jira(["Stata", "Python"])
 
-        updated, final_set, added = jus.update_software_field(jira, "AEAREP-1", {"Stata"})
+        updated, final_checkbox, added, invalid = jus.update_software_field(jira, "AEAREP-1", {"Stata"})
 
         self.assertFalse(updated)
         self.assertEqual(added, set())
         issue.update.assert_not_called()
 
-    def test_strips_unknown_placeholder_when_adding_real_software(self):
-        jira = MagicMock()
-        issue = self._mock_issue(["Unknown"])
-        jira.issue.return_value = issue
+    def test_invalid_value_goes_to_other_field_and_posts_comment(self):
+        jira, issue = self._mock_jira([])
 
-        updated, final_set, added = jus.update_software_field(jira, "AEAREP-1", {"Stata"})
+        updated, final_checkbox, added, invalid = jus.update_software_field(jira, "AEAREP-1", {"Stata", "SPSS"})
 
         self.assertTrue(updated)
-        self.assertEqual(final_set, {"Stata"})
-        self.assertEqual(added, {"Stata"})
-        issue.update.assert_called_once_with(fields={jus.SOFTWARE_FIELD: ["Stata"]})
+        self.assertEqual(final_checkbox, {"Stata"})
+        self.assertEqual(invalid, {"SPSS"})
+        issue.update.assert_called_once_with(
+            fields={CHECKBOX_FIELD_ID: [{"value": "Stata"}], OTHER_FIELD_ID: "SPSS"}
+        )
+        jira.add_comment.assert_called_once()
 
-    def test_strips_unknown_even_if_detected_software_already_present(self):
-        jira = MagicMock()
-        issue = self._mock_issue(["Unknown", "Stata"])
-        jira.issue.return_value = issue
+    def test_invalid_value_merges_with_existing_other_text(self):
+        jira, issue = self._mock_jira([], current_other="Excel")
 
-        updated, final_set, added = jus.update_software_field(jira, "AEAREP-1", {"Stata"})
+        updated, final_checkbox, added, invalid = jus.update_software_field(jira, "AEAREP-1", {"SPSS"})
 
         self.assertTrue(updated)
-        self.assertEqual(final_set, {"Stata"})
-        self.assertEqual(added, set())
-        issue.update.assert_called_once_with(fields={jus.SOFTWARE_FIELD: ["Stata"]})
+        self.assertEqual(invalid, {"SPSS"})
+        issue.update.assert_called_once_with(fields={OTHER_FIELD_ID: "Excel, SPSS"})
+
+    def test_no_comment_when_all_values_are_valid(self):
+        jira, issue = self._mock_jira([])
+
+        jus.update_software_field(jira, "AEAREP-1", {"Stata"})
+
+        jira.add_comment.assert_not_called()
 
     def test_retries_on_transient_screen_error_then_succeeds(self):
         from jira.exceptions import JIRAError
 
-        jira = MagicMock()
-        issue = self._mock_issue([])
-        jira.issue.return_value = issue
+        jira, issue = self._mock_jira([])
         transient = JIRAError(
-            text="Field 'customfield_10028' cannot be set. It is not on the appropriate screen, or unknown.",
+            text=f"Field '{CHECKBOX_FIELD_ID}' cannot be set. It is not on the appropriate screen, or unknown.",
             status_code=400,
         )
         issue.update.side_effect = [transient, transient, None]
         sleeps = []
 
-        updated, final_set, added = jus.update_software_field(
+        updated, final_checkbox, added, invalid = jus.update_software_field(
             jira, "AEAREP-1", {"Stata"}, retry_delays=(2, 5, 10), sleep=sleeps.append
         )
 
         self.assertTrue(updated)
-        self.assertEqual(final_set, {"Stata"})
+        self.assertEqual(final_checkbox, {"Stata"})
         self.assertEqual(issue.update.call_count, 3)
         self.assertEqual(sleeps, [2, 5])
 
     def test_gives_up_after_exhausting_retries(self):
         from jira.exceptions import JIRAError
 
-        jira = MagicMock()
-        issue = self._mock_issue([])
-        jira.issue.return_value = issue
+        jira, issue = self._mock_jira([])
         transient = JIRAError(
-            text="Field 'customfield_10028' cannot be set. It is not on the appropriate screen, or unknown.",
+            text=f"Field '{CHECKBOX_FIELD_ID}' cannot be set. It is not on the appropriate screen, or unknown.",
             status_code=400,
         )
         issue.update.side_effect = transient
@@ -271,9 +291,7 @@ class TestUpdateSoftwareField(unittest.TestCase):
     def test_does_not_retry_unrelated_error(self):
         from jira.exceptions import JIRAError
 
-        jira = MagicMock()
-        issue = self._mock_issue([])
-        jira.issue.return_value = issue
+        jira, issue = self._mock_jira([])
         unrelated = JIRAError(text="Some other failure entirely", status_code=500)
         issue.update.side_effect = unrelated
         sleeps = []


### PR DESCRIPTION
## Summary
- The old `customfield_10028` free-text labels field intermittently failed with a "not on the appropriate screen" 400 error and had no enforced vocabulary, producing dozens of inconsistent variants (Matlab/MATLAB, python/Python, etc).
- Renamed it to "Software used (v1)" in Jira, unmapped it from all screens (one exception left on purpose), and replaced it with a checkboxes field ("Software used": Stata, MATLAB, R, Python, SAS, Julia, Excel, Fortran, Mathematica, Dynare, QGIS, ArcGIS) plus a free-text "Software used (other)" field.
- All Jira field IDs are now resolved dynamically by display name (`jira.fields()`) instead of being hardcoded, so this doesn't repeat when fields get recreated.
- Adds `tools/jira_software_field_report.py` (live frequency report used to pick the checkbox options) and `tools/jira_migrate_software_field.py` (one-off migration script).
- `tools/jira_update_software.py` now partitions newly detected software between the checkbox and "other" fields, and posts an issue comment when it detects software outside the checkbox options.

## Data migration (already run live)
- All 4,521 AEAREP issues with "Software used (v1)" data were migrated: 4,435 now have checkbox values, 218 have "other" text values, 0 errors.
- 68 issues that only had the old "Unknown" placeholder were cleaned up (blanked, since "Unknown" isn't a real software name).

## Test plan
- [x] `python3 tools/test_jira_update_software.py` — 32 tests pass
- [x] `jira_software_field_report.py` dry run against live Jira confirmed frequency table
- [x] `jira_migrate_software_field.py` dry run then `--yes` run verified against spot-checked issues, confirmed idempotent
- [x] `jira_update_software.py` live-tested end-to-end: valid software → checkbox, invalid software → "other" field + comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)