### PR TITLE
Make REPLICATION.md fragment insertion idempotent

### DIFF
--- a/tools/replace_placeholders.py
+++ b/tools/replace_placeholders.py
@@ -18,12 +18,13 @@ TEMPLATE='REPLICATION.md'
 # byte-for-byte identical (git neutral), while changed content updates only
 # the fragment between the markers, leaving surrounding human edits alone.
 BEGIN_MARKER = "<!-- BEGIN GENERATED: {tag} -->"
+DO_NOT_EDIT_NOTICE = "<!-- Auto-generated content; do not edit by hand, changes will be overwritten -->"
 END_MARKER = "<!-- END GENERATED: {tag} -->"
 
 def replace_content(template,replacement,tag):
     begin = BEGIN_MARKER.format(tag=tag)
     end = END_MARKER.format(tag=tag)
-    wrapped = f"{begin}\n{replacement.strip()}\n{end}"
+    wrapped = f"{begin}\n{DO_NOT_EDIT_NOTICE}\n{replacement.strip()}\n{end}"
 
     # If a previously-inserted fragment for this tag already exists, replace
     # just the content between its markers with the (possibly updated) content.

--- a/tools/replace_placeholders.py
+++ b/tools/replace_placeholders.py
@@ -1,5 +1,6 @@
 # script to replace placeholders in REPLICATION.md with generated content
 import os
+import re
 import shutil
 import argparse
 
@@ -10,10 +11,36 @@ except ImportError:
 
 TEMPLATE='REPLICATION.md'
 
+# Fragments inserted by this script are wrapped in HTML comment markers so that
+# later runs can find and replace them again, even after the original
+# "{{ tag }}" placeholder has already been consumed. This keeps repeated runs
+# idempotent: re-running with unchanged generated content leaves the file
+# byte-for-byte identical (git neutral), while changed content updates only
+# the fragment between the markers, leaving surrounding human edits alone.
+BEGIN_MARKER = "<!-- BEGIN GENERATED: {tag} -->"
+END_MARKER = "<!-- END GENERATED: {tag} -->"
+
 def replace_content(template,replacement,tag):
-    new_content = template.replace("{{ "+tag+" }}", replacement)
-    return new_content
-    
+    begin = BEGIN_MARKER.format(tag=tag)
+    end = END_MARKER.format(tag=tag)
+    wrapped = f"{begin}\n{replacement.strip()}\n{end}"
+
+    # If a previously-inserted fragment for this tag already exists, replace
+    # just the content between its markers with the (possibly updated) content.
+    marker_pattern = re.compile(re.escape(begin) + r".*?" + re.escape(end), re.DOTALL)
+    if marker_pattern.search(template):
+        return marker_pattern.sub(lambda m: wrapped, template)
+
+    # Otherwise, this is the first insertion: replace the raw "{{ tag }}"
+    # placeholder with the marker-wrapped content.
+    placeholder = "{{ "+tag+" }}"
+    if placeholder in template:
+        return template.replace(placeholder, wrapped)
+
+    # Neither a placeholder nor previously-inserted markers were found: leave
+    # the template untouched (the fragment isn't referenced anywhere).
+    return template
+
 
             
 if __name__=='__main__':


### PR DESCRIPTION
## Summary
- `tools/replace_placeholders.py` previously replaced `{{ tag }}` placeholders in `REPLICATION.md` in-place and consumed them permanently: once a fragment was inserted and committed, later runs had no way to find and update it again since the placeholder text was gone.
- Each inserted fragment is now wrapped in `<!-- BEGIN GENERATED: tag -->` / `<!-- END GENERATED: tag -->` HTML comment markers, with a one-line "do not edit by hand" notice inside the wrapper.
- On each run, if a marker block for a tag already exists, only the content between the markers is replaced with the latest generated content; otherwise the script falls back to replacing the raw `{{ tag }}` placeholder (first-time insertion). If neither is found, the template is left untouched.
- This makes repeated runs of `aeaready`/`automations/24_amend_report.sh` (and `tools/generate_sivacor_partb.sh`) git-neutral when generated content is unchanged, while still allowing changed generated content to update previously-inserted fragments without disturbing surrounding manual edits.

## Test plan
- [x] Verified idempotency on a scratch template: two consecutive runs with unchanged generated content produce byte-identical output.
- [x] Verified that changing generated content updates only the fragment between markers, leaving surrounding human edits intact.
- [x] Ran against the repo's actual `REPLICATION.md` with sample content for all real fragment tags (`zip-warning.md`, `pii-summary.md`, `software-warnings.md`, sivacor fragments, etc.) and confirmed two consecutive runs are identical.

https://claude.ai/code/session_01U4VMBYNUJfVCUBLb6kiFwR


---
_Generated by [Claude Code](https://claude.ai/code/session_01U4VMBYNUJfVCUBLb6kiFwR)_