### PR TITLE
Detect .mod (Dynare) files in software/program scanning

### DIFF
--- a/automations/04_list_program_files.sh
+++ b/automations/04_list_program_files.sh
@@ -26,7 +26,7 @@ then
   mkdir generated
 fi
 
-extensions="ado do r rmd qmd ox m py nb ipynb sas jl f f90 c c++ sh toml yaml yml toml fs fsx gss cpp h"
+extensions="ado do r rmd qmd ox m mod py nb ipynb sas jl f f90 c c++ sh toml yaml yml toml fs fsx gss cpp h"
 # these usually do not have extensions
 fullnames="makefile"
 

--- a/tools/software-extensions.csv
+++ b/tools/software-extensions.csv
@@ -5,6 +5,7 @@ r,R
 rmd,R
 ox,Ox
 m,MATLAB
+mod,Dynare
 py,Python
 sas,SAS
 jl,Julia


### PR DESCRIPTION
## Summary
- Added `mod` to the program-file extension list in `automations/04_list_program_files.sh` so Dynare `.mod` files are picked up by the program-file listing/manifest step (`programs-list.txt`, `programs-summary.txt`, `programs-metadata.csv`).
- Added a `mod,Dynare` row to `tools/software-extensions.csv` so the Jira software-field detection (`tools/jira_update_software.py`) also recognizes `.mod` files and tags the issue with "Dynare".

## Test plan
- [x] Ran `automations/04_list_program_files.sh` against a scratch directory containing a `.mod` file; confirmed `programs-list.txt` lists it and `programs-summary.txt` reports `1 mod files`.
- [x] Verified `tools/software-extensions.csv` parses correctly and maps `mod` → `Dynare`.
- [x] Ran `tools/test_jira_update_software.py`; all failures are a pre-existing missing `jira` module in this environment, unrelated to this change.

https://claude.ai/code/session_01U4VMBYNUJfVCUBLb6kiFwR


---
_Generated by [Claude Code](https://claude.ai/code/session_01U4VMBYNUJfVCUBLb6kiFwR)_