### PR TITLE
Fix Software-used field 400 when Jira editmeta omits the checkbox field

### DIFF
--- a/automations/26_update_jira_software.sh
+++ b/automations/26_update_jira_software.sh
@@ -25,9 +25,7 @@
 _project_dir="${1:-}"
 _tag="${2:-}"
 
-if command -v python3.12 &>/dev/null; then
-    PYTHON_CMD="python3.12"
-elif command -v python3 &>/dev/null; then
+if command -v python3 &>/dev/null; then
     PYTHON_CMD="python3"
 else
     echo "26_update_jira_software: no Python 3 found, skipping" >&2

--- a/tests/test_jira_update_software.py
+++ b/tests/test_jira_update_software.py
@@ -173,17 +173,21 @@ class _Option:
 
 
 class TestUpdateSoftwareField(unittest.TestCase):
-    def _mock_jira(self, current_checkbox, current_other=None, checkbox_options=CHECKBOX_OPTIONS):
+    def _mock_jira(self, current_checkbox, current_other=None, checkbox_options=CHECKBOX_OPTIONS,
+                   checkbox_on_screen=True, other_on_screen=True):
         jira = MagicMock()
         jira.fields.return_value = [
             {"name": jus.CHECKBOX_FIELD_NAME, "id": CHECKBOX_FIELD_ID},
             {"name": jus.OTHER_FIELD_NAME, "id": OTHER_FIELD_ID},
         ]
-        jira.editmeta.return_value = {
-            "fields": {
-                CHECKBOX_FIELD_ID: {"allowedValues": [{"value": v} for v in checkbox_options]},
+        editmeta_fields = {}
+        if checkbox_on_screen:
+            editmeta_fields[CHECKBOX_FIELD_ID] = {
+                "allowedValues": [{"value": v} for v in checkbox_options]
             }
-        }
+        if other_on_screen:
+            editmeta_fields[OTHER_FIELD_ID] = {"schema": {"type": "string"}}
+        jira.editmeta.return_value = {"fields": editmeta_fields}
         issue = MagicMock()
         setattr(issue.fields, CHECKBOX_FIELD_ID, [_Option(v) for v in current_checkbox])
         setattr(issue.fields, OTHER_FIELD_ID, current_other)
@@ -250,6 +254,57 @@ class TestUpdateSoftwareField(unittest.TestCase):
         jus.update_software_field(jira, "AEAREP-1", {"Stata"})
 
         jira.add_comment.assert_not_called()
+
+    def test_editmeta_missing_checkbox_falls_back_to_known_options(self):
+        # Regression (AEAREP-10057): when editmeta omits the checkbox field,
+        # standard packages must not be misclassified as invalid and routed to
+        # the "other" text field.
+        jira, issue = self._mock_jira([], checkbox_on_screen=False)
+
+        updated, final_checkbox, added, invalid = jus.update_software_field(
+            jira, "AEAREP-1", {"Python", "R", "Stata"}, retry_delays=()
+        )
+
+        self.assertTrue(updated)
+        self.assertEqual(final_checkbox, {"Python", "R", "Stata"})
+        self.assertEqual(invalid, set())
+        issue.update.assert_called_once_with(
+            fields={CHECKBOX_FIELD_ID: [{"value": "Python"}, {"value": "R"}, {"value": "Stata"}]}
+        )
+        jira.add_comment.assert_not_called()
+
+    def test_editmeta_retried_until_checkbox_field_appears(self):
+        jira, issue = self._mock_jira([])
+        jira.editmeta.side_effect = [
+            {"fields": {OTHER_FIELD_ID: {"schema": {"type": "string"}}}},
+            {"fields": {
+                CHECKBOX_FIELD_ID: {"allowedValues": [{"value": v} for v in CHECKBOX_OPTIONS]},
+                OTHER_FIELD_ID: {"schema": {"type": "string"}},
+            }},
+        ]
+        sleeps = []
+
+        updated, _, _, invalid = jus.update_software_field(
+            jira, "AEAREP-1", {"Stata"}, retry_delays=(3, 7), sleep=sleeps.append
+        )
+
+        self.assertEqual(jira.editmeta.call_count, 2)
+        self.assertEqual(sleeps, [3])
+        self.assertEqual(invalid, set())
+
+    def test_invalid_value_not_recorded_when_other_field_off_screen(self):
+        jira, issue = self._mock_jira([], other_on_screen=False)
+
+        updated, final_checkbox, added, invalid = jus.update_software_field(
+            jira, "AEAREP-1", {"Stata", "SPSS"}, retry_delays=()
+        )
+
+        self.assertTrue(updated)
+        self.assertEqual(final_checkbox, {"Stata"})
+        self.assertEqual(invalid, {"SPSS"})
+        issue.update.assert_called_once_with(fields={CHECKBOX_FIELD_ID: [{"value": "Stata"}]})
+        jira.add_comment.assert_called_once()
+        self.assertIn("not on this issue's edit screen", jira.add_comment.call_args[0][1])
 
     def test_retries_on_transient_screen_error_then_succeeds(self):
         from jira.exceptions import JIRAError

--- a/tools/jira_update_software.py
+++ b/tools/jira_update_software.py
@@ -55,6 +55,20 @@ OTHER_FIELD_NAME = "Software used (other)"
 # failure and is not retried.
 RETRY_DELAYS_SECONDS = (2, 5, 10)
 
+# The configured options on the "Software used" checkbox field (see the commit
+# "Replace free-text Software used field with checkbox + other-text structure").
+# Used as a fallback when the issue's editmeta omits the checkbox field: the
+# same intermittent "not on the appropriate screen" flakiness that
+# RETRY_DELAYS_SECONDS works around for writes also affects editmeta reads.
+# Without this fallback, an empty option set makes every detected package look
+# like a non-option, routing it to the "Software used (other)" text field -
+# which is not on every issue's edit screen and then rejects the write with a
+# 400. Keep this list in sync with the field's Jira configuration.
+KNOWN_CHECKBOX_OPTIONS = frozenset({
+    "Stata", "MATLAB", "R", "Python", "SAS", "Julia",
+    "Excel", "Fortran", "Mathematica", "Dynare", "QGIS", "ArcGIS",
+})
+
 DEFAULT_EXT_LOOKUP = Path(__file__).resolve().parent / "software-extensions.csv"
 DEFAULT_NAME_LOOKUP = Path(__file__).resolve().parent / "software-filenames.csv"
 
@@ -197,13 +211,42 @@ def resolve_fields(jira):
     return checkbox_id, other_id
 
 
-def fetch_checkbox_options(jira, issue, checkbox_field_id):
-    """Fetch the checkbox field's configured option labels via the issue's editmeta."""
-    meta = jira.editmeta(issue)
-    field_meta = meta.get("fields", {}).get(checkbox_field_id)
-    if not field_meta:
-        return set()
-    return {opt["value"] for opt in field_meta.get("allowedValues", [])}
+def fetch_editmeta_fields(jira, issue, checkbox_field_id, retry_delays=RETRY_DELAYS_SECONDS, sleep=time.sleep):
+    """
+    Return the issue's editmeta "fields" dict (field-id -> metadata).
+
+    Jira Cloud intermittently returns editmeta without the "Software used"
+    checkbox field even though it is on the edit screen (the same screen-
+    resolution flakiness RETRY_DELAYS_SECONDS works around for writes), so
+    retry a few times until the checkbox field appears before giving up.
+    """
+    fields = {}
+    for delay in (None, *retry_delays):
+        if delay is not None:
+            sleep(delay)
+        fields = jira.editmeta(issue).get("fields", {}) or {}
+        if checkbox_field_id in fields:
+            return fields
+    return fields
+
+
+def checkbox_options_from_editmeta(editmeta_fields, checkbox_field_id):
+    """
+    Extract the checkbox field's configured option labels from an editmeta
+    fields dict, falling back to KNOWN_CHECKBOX_OPTIONS (with a warning) when
+    editmeta omits the field or lists no options - returning an empty set here
+    would misclassify every detected package as a non-option.
+    """
+    field_meta = editmeta_fields.get(checkbox_field_id) or {}
+    options = {opt["value"] for opt in field_meta.get("allowedValues", [])}
+    if not options:
+        print(
+            f"Warning: Jira editmeta returned no options for '{CHECKBOX_FIELD_NAME}' "
+            f"({checkbox_field_id}); falling back to the known option list.",
+            file=sys.stderr,
+        )
+        return set(KNOWN_CHECKBOX_OPTIONS)
+    return options
 
 
 def _is_transient_screen_error(exc, field_ids):
@@ -221,8 +264,13 @@ def update_software_field(jira, issue_key, new_software, retry_delays=RETRY_DELA
     Partition new_software into checkbox-valid and invalid (not a configured
     checkbox option), union the valid ones into the checkbox field and the
     invalid ones into the "other" text field, and update Jira only if that
-    changes either field. When invalid values are recorded, also posts an
-    issue comment noting they weren't a checkbox option.
+    changes either field. Invalid values are only written to the "other"
+    field when it is on the issue's edit screen; either way a comment is
+    posted noting anything that wasn't a checkbox option.
+
+    The set of valid checkbox options comes from the issue's editmeta, with
+    retries and a KNOWN_CHECKBOX_OPTIONS fallback for Jira Cloud's
+    intermittent habit of omitting the field from editmeta.
 
     Retries the write on Jira's intermittent transient screen-validation
     error (see RETRY_DELAYS_SECONDS), sleeping between attempts via `sleep`
@@ -236,7 +284,10 @@ def update_software_field(jira, issue_key, new_software, retry_delays=RETRY_DELA
     checkbox_id, other_id = resolve_fields(jira)
     issue = jira.issue(issue_key)
 
-    checkbox_options = fetch_checkbox_options(jira, issue, checkbox_id)
+    editmeta_fields = fetch_editmeta_fields(jira, issue, checkbox_id, retry_delays, sleep)
+    checkbox_options = checkbox_options_from_editmeta(editmeta_fields, checkbox_id)
+    other_on_screen = other_id in editmeta_fields
+
     current_checkbox = {opt.value for opt in (getattr(issue.fields, checkbox_id, None) or [])}
     current_other = getattr(issue.fields, other_id, None) or ""
     current_other_values = {v.strip() for v in current_other.split(",") if v.strip()}
@@ -244,8 +295,15 @@ def update_software_field(jira, issue_key, new_software, retry_delays=RETRY_DELA
     valid = {name for name in new_software if name in checkbox_options}
     invalid = {name for name in new_software if name not in checkbox_options}
 
+    # Only route invalid values into the "other" text field when it is actually
+    # on this issue's edit screen; otherwise the write is rejected with a 400
+    # and the checkbox update is lost along with it. Unrecordable values are
+    # still surfaced via the issue comment below and the "Software detected:"
+    # stdout line.
+    record_other = bool(invalid) and other_on_screen
+
     final_checkbox = current_checkbox | valid
-    final_other_values = current_other_values | invalid
+    final_other_values = current_other_values | invalid if record_other else current_other_values
     final_other = ", ".join(sorted(final_other_values))
 
     added_checkbox = final_checkbox - current_checkbox
@@ -269,12 +327,16 @@ def update_software_field(jira, issue_key, new_software, retry_delays=RETRY_DELA
                     continue
                 raise
 
-        if invalid:
-            jira.add_comment(
-                issue,
-                f"Detected software not in the '{CHECKBOX_FIELD_NAME}' checkbox options, "
-                f"recorded in '{OTHER_FIELD_NAME}' instead: {', '.join(sorted(invalid))}",
-            )
+    if invalid and invalid - current_other_values:
+        if record_other:
+            tail = f"recorded in '{OTHER_FIELD_NAME}' instead"
+        else:
+            tail = f"could not be recorded - the '{OTHER_FIELD_NAME}' field is not on this issue's edit screen"
+        jira.add_comment(
+            issue,
+            f"Detected software not in the '{CHECKBOX_FIELD_NAME}' checkbox options, "
+            f"{tail}: {', '.join(sorted(invalid))}",
+        )
 
     return updated, final_checkbox, added_checkbox, invalid
 


### PR DESCRIPTION
## Problem

`automations/26_update_jira_software.sh` (via `tools/jira_update_software.py`) intermittently fails on tickets like **AEAREP-10057**:

```
Failed to update AEAREP-10057: JiraError HTTP 400
text: Field 'customfield_10554' cannot be set. It is not on the appropriate screen, or unknown.
Software detected: Python R Stata
```

## Root cause

Field-name resolution is **correct** — `customfield_10553` = "Software used" (checkbox), `customfield_10554` = "Software used (other)" (text). The bug is downstream:

1. `fetch_checkbox_options()` read the checkbox field's allowed options from the issue's `editmeta`.
2. Jira Cloud intermittently returns `editmeta` **without** the checkbox field (the same "not on the appropriate screen" flakiness the module already documents and retries for *writes*).
3. On that path the function returned an empty set, so **every** detected package — even Stata/R/Python — was classified as *not a checkbox option* and routed to the `customfield_10554` "Software used (other)" text field.
4. That field is not on this issue type's edit screen, so the write is rejected with a 400. The checkbox update is lost with it. Retrying doesn't help because the field genuinely isn't on the screen.

"Sometimes works" = the runs where `editmeta` happened to include the checkbox field, so classification was correct and only `customfield_10553` was written.

## Fix

- **`fetch_editmeta_fields()`** — retry `editmeta` until the checkbox field appears (reusing `RETRY_DELAYS_SECONDS`).
- **`checkbox_options_from_editmeta()`** — fall back to a new `KNOWN_CHECKBOX_OPTIONS` constant (Stata, MATLAB, R, Python, SAS, Julia, Excel, Fortran, Mathematica, Dynare, QGIS, ArcGIS) with a stderr warning, instead of returning an empty set.
- **Defense in depth** — only write `customfield_10554` when it is actually on the issue's edit screen; otherwise skip that write (keeping the checkbox update) and post an explanatory comment. The `Software detected:` stdout line already forwards to `70_publish_comment.sh` as a durable fallback.

## Also in this PR

- `automations/26_update_jira_software.sh`: drop the `python3.12` preference and just use `python3` (the pipeline image provides a suitable one; preferring a possibly-absent interpreter risked picking an env without the `jira` package).

## Tests

`tests/test_jira_update_software.py`: `_mock_jira` now models per-field edit-screen presence; added regression tests for the missing-checkbox fallback (the AEAREP-10057 scenario), the editmeta retry, and the off-screen "other" field path. `python3 tests/test_jira_update_software.py` → 35 pass; full `tests/` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)